### PR TITLE
close-day skill: per-day totals + GitHub sync check

### DIFF
--- a/.claude/skills/close-day/SKILL.md
+++ b/.claude/skills/close-day/SKILL.md
@@ -77,7 +77,9 @@ print([d.isoformat() for d in pending])
 
 - Weekends are never *required* — but if a weekend day in the gap has logs,
   mention it to Carlos and offer to include it.
-- Process pending days **oldest first**, one full pass (Steps 1–4) per day.
+- Process pending days **oldest first**, one full pass (Steps 1–5) per day.
+  The GitHub sync check (Step 4) only needs to run once per *task*, on its
+  final pass — the Hours field is a per-sprint running total, not per-day.
 - If today is the only pending day, this is the normal single-day flow.
 - If an **active timer** is running while closing *today*, it must be stopped
   first — running time isn't in `logs[]` yet, so the summary would undercount.
@@ -172,7 +174,35 @@ wt.save(data)
 Run these sequentially (the JSON file is read-modify-written), then re-print
 the Step 1 summary so Carlos sees the corrected day total.
 
-## Step 4 — Mark the day closed
+## Step 4 — GitHub issue sync check
+
+For every task that got time today (the Step 1 list) and has a linked
+`github_issue`, verify the GH Project's Hours field matches our data. The
+value GitHub should show is the **sprint-filtered** local total rounded to
+quarter hours — exactly what `sync_project_hours()` writes:
+
+```python
+import wt
+data = wt.load()
+sprints = wt.get_cached_sprints(data)
+for t in todays_tasks:                       # tasks with logs today, from Step 1
+    issue = t.get("github_issue")
+    expected = wt.mins_to_quarter_hours(wt.task_logged_mins_for_sprint(t, sprints))
+    gh = wt.get_project_hours(issue, data) if issue else None   # network call per issue
+    print(t["title"], t.get("github_repo"), t.get("activity"), expected, gh)
+```
+
+- **In sync**: `gh == expected` — nothing to do.
+- **Mismatch**: confirm with Carlos, then `wt.sync_project_hours(issue, t, data)`
+  (re-syncs Status/Activity/Type/Sprint/Hours in one shot; run sequentially,
+  it makes several network calls per issue). It marks logs uploaded in the
+  local data — `wt.save(data)` after, minding the TUI clobber gotcha.
+- **No linked issue**: nothing to verify; flag it if the task *does* have a
+  `github_repo` (an issue is expected eventually via the close workflow).
+- `gh is None` with an issue linked usually means the issue isn't in the
+  configured project — surface it rather than silently passing.
+
+## Step 5 — Mark the day closed
 
 Only after Carlos confirms the day looks right (for *today*, that means he's
 actually signing off):
@@ -192,9 +222,17 @@ wt.save(data)
 
 Idempotent — re-closing an already-closed day just refreshes its stored total.
 
-## Step 5 — Sign-off recap
+## Step 6 — Sign-off recap
 
-After the last pending day is closed, give Carlos a one-screen recap: total
-time per closed day, meetings logged during this session, and anything left
-deliberately open (skipped meetings, a zero-log day he chose to close anyway).
+After the last pending day is closed, give Carlos a one-screen recap:
+
+1. **Per-task table** for the closed day(s), one row per task with time today:
+   Task | Repo | Activity | Today | Sprint (local) | GitHub — where *Sprint
+   (local)* is `task_logged_mins_for_sprint()` and *GitHub* is the project
+   Hours field from Step 4 (with a ✓/✗ sync indicator). Use `—` for tasks
+   without a repo/issue.
+2. Total time per closed day and meetings logged during this session.
+3. Anything left deliberately open (skipped meetings, sync mismatches Carlos
+   chose not to fix, a zero-log day he closed anyway).
+
 Remind him to press `r` in the TUI if it's open, so it picks up the new logs.

--- a/.claude/skills/close-day/SKILL.md
+++ b/.claude/skills/close-day/SKILL.md
@@ -35,9 +35,23 @@ wiped by the stop's async hours sync). When the TUI is open (bridge answers on
 
 ## State: `config.closed_days`
 
-A sorted, deduped list of ISO dates (`"2026-07-22"`) in
-`data["config"]["closed_days"]`. A date in the list = that day was closed via
-this workflow. The list lives in the shared data file, so it syncs across Macs.
+A dict in `data["config"]["closed_days"]` mapping ISO date → **total minutes
+logged that day** (the Step 1 grand total: non-shadow tasks only), kept sorted
+by key:
+
+```json
+{"2026-07-22": 412.24, "2026-07-23": 390.0}
+```
+
+A key present = that day was closed via this workflow. The per-day total is
+stored so longer-term analysis can read one number per day instead of
+re-scanning every task's logs. It's a **snapshot at close time** — later log
+edits aren't reflected; recompute from logs (Step 1 snippet) when exactness
+matters. The dict lives in the shared data file, so it syncs across Macs.
+
+**Legacy format**: the first version stored a plain list of ISO dates. If a
+list is found, migrate in place first: recompute each listed day's total with
+the Step 1 snippet and rewrite the key as a dict.
 
 **First run** (key missing): don't invent a backlog. Ask Carlos which date to
 start from (default: today), then treat only weekdays from that date onward as
@@ -49,7 +63,10 @@ requiring closure.
 import wt
 from datetime import date, timedelta
 data = wt.load()
-closed = set(data.get("config", {}).get("closed_days", []))
+closed = data.get("config", {}).get("closed_days", {})
+if isinstance(closed, list):          # legacy list format — migrate first (see State)
+    closed = {d: None for d in closed}
+closed = set(closed)                  # ISO date strings (dict keys)
 today = date.today()
 # Weekdays from the day after the newest closed day through today, not yet closed.
 start = date.fromisoformat(max(closed)) + timedelta(days=1) if closed else today
@@ -160,16 +177,20 @@ the Step 1 summary so Carlos sees the corrected day total.
 Only after Carlos confirms the day looks right (for *today*, that means he's
 actually signing off):
 
+Record the day with its Step 1 grand total (in minutes):
+
 ```python
 import wt
 data = wt.load()
-closed = set(data.setdefault("config", {}).get("closed_days", []))
-closed.add(day.isoformat())
-data["config"]["closed_days"] = sorted(closed)
+cd = data.setdefault("config", {}).get("closed_days", {})
+if isinstance(cd, list):              # legacy list format
+    cd = {d: None for d in cd}        # backfill totals via the Step 1 snippet
+cd[day.isoformat()] = round(total, 2) # `total` from the (post-Step-3) Step 1 summary
+data["config"]["closed_days"] = dict(sorted(cd.items()))
 wt.save(data)
 ```
 
-Idempotent — re-closing an already-closed day is a no-op.
+Idempotent — re-closing an already-closed day just refreshes its stored total.
 
 ## Step 5 — Sign-off recap
 


### PR DESCRIPTION
Two follow-ups to #24 requested by Carlos:

**Per-day totals** — `config.closed_days` changes from `["2026-07-22"]` to `{"2026-07-22": 412.29}` (ISO date → total minutes logged that day, snapshot at close time), so long-term analysis reads one number per day instead of re-scanning task logs. Legacy list format migrates in place; the live data file is already migrated.

**GitHub sync check (new Step 4)** — for each task with time logged today that has a linked issue, compare `mins_to_quarter_hours(task_logged_mins_for_sprint(...))` against the GH Project Hours field (`get_project_hours`), and fix mismatches via `sync_project_hours()` after confirmation. The sign-off recap becomes a per-task table: Task | Repo | Activity | Today | Sprint (local) | GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)