### PR TITLE
Replace shadow tasks with per-sprint GitHub issue bindings (Option A)

### DIFF
--- a/.claude/skills/close-sprint/SKILL.md
+++ b/.claude/skills/close-sprint/SKILL.md
@@ -1,25 +1,37 @@
 ---
 name: close-sprint
-description: Carlos's end-of-sprint checklist — close the previous sprint's recurrent tasks, recreate them for the new sprint, split non-recurrent tasks with hours in the closed sprint (marker-log technique), and re-point stray open tasks to the current sprint. Trigger when the user says "close the sprint", "close Sprint NN", "end of sprint", "sprint just ended", or similar at a sprint boundary.
+description: Carlos's end-of-sprint checklist — close the previous sprint's recurrent tasks, recreate them for the new sprint, then reconcile every other task's per-sprint GitHub issues with `wt sync-sprints`. Trigger when the user says "close the sprint", "close Sprint NN", "end of sprint", "sprint just ended", or similar at a sprint boundary.
 ---
 
 # Close a sprint (end-of-sprint workflow)
 
-Run at every sprint boundary (sprints are 2 weeks; e.g. Sprint 103 = Jun 29 →
-Jul 13). "Previous sprint" below = the sprint being closed; "current sprint" =
+Run at every sprint boundary (sprints are 2 weeks; e.g. Sprint 105 = Jul 27 →
+Aug 10). "Previous sprint" below = the sprint being closed; "current sprint" =
 the one that just started. Every mutating step must be **confirmed with Carlos
 first** — do all the read-only analysis, present the full plan, then execute.
+
+> **This workflow changed.** Tasks are no longer "assigned" to one sprint and
+> re-pointed forward, and cross-sprint work no longer creates duplicate *shadow
+> tasks*. Each task now carries `sprint_issues[]` — one binding per sprint,
+> `{sprint_id, sprint, issue, state, hours_synced}` — and its per-sprint hours
+> are derived from log timestamps. The old **marker-log technique is gone**;
+> do not append 0-minute rollover logs. See `docs/plan-sprint-bindings.md`.
 
 ## Step 0 — Preconditions (Carlos does this manually)
 
 Carlos verifies all hours are logged on the previous sprint's **recurrent**
-tasks before asking to close the sprint. Don't re-audit those, but DO check
-for misfiled logs: a recurrent task's per-sprint copy sometimes accumulates
-logs dated in the *next* sprint (e.g. a timer left running on the old copy).
-For each `Time tracking - Sprint N`-style pair, bucket the logs with
-`wt.bucket_logs_by_sprint()` and move any next-sprint logs to the next-sprint
-copy, then `wt.sync_project_hours()` on **both** issues (it recomputes
-sprint-filtered totals from scratch and fixes the GH Hours fields).
+tasks before asking to close the sprint. Don't re-audit those.
+
+**Do still check recurrent copies for misfiled logs.** Recurrent tasks are
+still one task object per sprint (unifying them into a single task with one
+binding per sprint is a later, separate phase), so a timer left running on the
+old `… - Sprint N` copy leaves next-sprint logs on the wrong object. For each
+`… - Sprint N` pair, bucket with `wt.bucket_logs_by_sprint()`, move any
+next-sprint logs to the next-sprint copy, then `wt.sync_project_hours()` on
+**both** issues.
+
+Non-recurrent tasks need no such repair: `wt sync-sprints` recomputes every
+sprint's hours from the logs, so moving a log and re-running fixes it.
 
 ## Step 1 — Close previous-sprint recurrent tasks
 
@@ -29,8 +41,8 @@ wt close-recurrent             # closes GH issues, sets Status=Done, syncs hours
 ```
 
 Only targets `status == "recurrent"` tasks with a linked issue in the sprint
-immediately before the current one. Recurrent copies without a linked issue
-are skipped silently — check the dry-run lists everything expected.
+immediately before the current one. Recurrent copies without a linked issue are
+skipped silently — check the dry-run lists everything expected.
 
 ## Step 2 — Recreate recurrent tasks for the current sprint
 
@@ -38,76 +50,65 @@ Use the `new-sprint-recurrent` skill / `wt new-recurrent` (preview with
 `--dry-run` first). Often a no-op if the new sprint's copies were already
 created at sprint start — "No recurring tasks … to recreate" is fine.
 
-## Step 3 — Split non-recurrent tasks with hours in the closed sprint
+## Step 3 — Reconcile everything else
 
-Goal: every open (non-done, non-recurrent, non-shadow) task with logged time
-in the closed sprint gets a **closed shadow task + GH issue carrying that
-sprint's hours**, and the main task moves to the current sprint (we're still
-working on it), with its issue's Hours showing only current-sprint time.
-
-Find candidates (read-only):
-
-```python
-import wt
-data = wt.load()
-sprints = wt.get_cached_sprints(data)
-for t in data["tasks"]:
-    if t.get("cross_sprint_parent") or t["status"] in ("recurrent", "done"):
-        continue
-    buckets = wt.bucket_logs_by_sprint(t, sprints)
-    # report tasks whose buckets include the closed sprint's id
-```
-
-Two cases:
-
-1. **Task already has logs in the current sprint** → plain split:
-   ```bash
-   wt split-sprint "<task>"
-   ```
-2. **Task has logs only in the closed sprint (or earlier)** → the split
-   machinery re-points the main task to the most recent sprint *with logs*,
-   which would be the closed one. Fix with the **marker-log technique**:
-   append a 0-minute log dated now before splitting:
-   ```python
-   t["logs"].append({
-       "id": wt.uid(), "minutes": 0,
-       "note": "Sprint rollover marker: work continues in Sprint <current>",
-       "at": time.time(),
-   })
-   wt.save(data)
-   ```
-   Then `wt split-sprint "<task>"`. The split now creates closed shadows for
-   *every* prior sprint with hours (there may be several — e.g. a task with
-   Sprint 102 + 103 hours gets two shadows), re-points the main task to the
-   current sprint, and sets the main issue's Hours to 0 (correct — the hours
-   live on the shadows; new time syncs as it's logged). **Keep the marker
-   log**: it also makes a later `wt done` idempotent — without it, closing
-   the task before logging new time would re-point it to the old sprint and
-   double-count hours against the shadow.
-
-Notes:
-- `wt split-sprint` prompts `Proceed? [Y/n]` — drive with `printf 'y\n' |`
-  after Carlos has approved the plan.
-- Run splits sequentially, never in parallel (the JSON file is
-  read-modify-written per invocation).
-- Splits are idempotent: already-split sprints are skipped (shadow exists).
-
-## Step 4 — Re-point stray open tasks
-
-Open tasks assigned to the closed sprint with **no logged time** just move
-forward (no shadow needed):
+This one command replaces the old "split each cross-sprint task, then re-point
+the strays" pair of steps.
 
 ```bash
-wt set-sprint "<task>" "Sprint <current>"
+wt sync-sprints --all --dry-run          # ALWAYS first — review the plan
+wt sync-sprints --all --create-issues    # then execute, with confirmation
 ```
 
-Also surface (but don't touch without asking) open tasks still pointing at
-*older* sprints — they're usually paused work Carlos may want to move, split,
-or close.
+What it does, per non-recurrent task:
 
-## Step 5 — Verify
+- buckets logs by sprint from their timestamps;
+- ensures a binding (and GitHub issue) exists for every sprint with time, plus
+  the current sprint for any open task — which is why no marker log is needed;
+- sets each binding's Hours from that sprint's minutes, only when it differs
+  from what was last synced;
+- closes any binding whose sprint has ended (Status=Done + `gh issue close`);
+- carries the task's long-lived issue forward to its most recent sprint.
 
-Re-run the candidate scan: no open non-shadow task should have unsplit hours
-in the closed sprint, and none should still be assigned to it. Spot-check one
-shadow issue on GitHub (Status=Done, Sprint, Hours). Remind Carlos to press
-`r` in the TUI to reload.
+Read the dry-run output carefully before approving:
+
+- **`create` lines mint a real GitHub issue.** `--all` deliberately does *not*
+  create issues unless `--create-issues` is passed — those sprints show as
+  `SKIP … re-run with --create-issues`. A first run over a long history can
+  want to mint a couple dozen issues for sprints that predate this workflow.
+  If the list contains old sprints Carlos doesn't want issues for, reconcile
+  those tasks individually instead of running `--all --create-issues`.
+- **`recurrent` tasks are always skipped** and listed as such — steps 1 and 2
+  own them.
+- Rounding is up-per-sprint (`mins_to_quarter_hours`), unchanged, so a stray
+  1-minute log in a sprint bills 0.25h. If a `create` line shows a suspiciously
+  tiny sprint, check whether that log is misfiled before approving.
+
+Single task, when you don't want a blanket run:
+
+```bash
+wt sync-sprints "<task>" --dry-run
+wt sync-sprints "<task>"
+```
+
+Notes:
+- It prompts `Proceed? [Y/n]`; drive with `printf 'y\n' |` or `--yes` once
+  Carlos has approved the plan.
+- Run sequentially, never in parallel (the JSON file is read-modify-written).
+- Idempotent — a second run reports "Nothing to do". Safe to re-run.
+- `wt split-sprint` still works as a deprecated alias.
+
+## Step 4 — Verify
+
+```bash
+python3 tools/check_invariants.py ~/.workload_tracker.json
+wt sprint                       # tasks grouped by the current sprint's bindings
+wt report --sprint "Sprint <previous>"
+```
+
+`check_invariants.py` should exit 0. It warns (not fails) about sprints with
+logged time and no binding — after a successful reconcile that list should be
+empty or only contain tasks you deliberately skipped. Spot-check one
+newly-created issue on GitHub (Status=Done, Sprint, Hours) and one
+carried-forward issue (Sprint = current, Hours = only this sprint's). Remind
+Carlos to press `r` in the TUI to reload.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,10 +41,32 @@ it runs on a background thread inside `tracker.py` while the TUI is open.
 
 Install/refresh dependencies: `pip install -r requirements.txt` (inside the venv).
 
-**Tests:** there is no automated test suite. Validate changes by exercising the
-CLI against the real (iCloud-synced) data file — use `--dry-run` flags where
-available (`close-recurrent`, `new-recurrent`) and prefer `wt.load()` in a
-throwaway `python3 -c` snippet to inspect state before mutating. Because the
+**Tests:** there is no pytest suite, but there are runnable stubbed harnesses
+under `tools/` — run these before and after any change to the sprint/GitHub
+paths:
+
+```bash
+# Never point these at the live file. Work on a copy.
+cp ~/.workload_tracker.json /tmp/wt-work.json
+python3 tools/baseline.py /tmp/wt-work.json /tmp/wt-baseline.json
+python3 tools/check_invariants.py /tmp/wt-work.json /tmp/wt-baseline.json
+python3 tools/test_reconcile.py  <pre-migration.json> <migrated.json> <baseline.json> <scratch-dir>
+python3 tools/test_phase3.py     <pre-migration.json> <migrated.json> <baseline.json> <scratch-dir>
+python3 tools/test_mcp_phase3.py <pre-migration.json> <migrated.json> <baseline.json> <scratch-dir>
+```
+
+**`WT_DATA_FILE` overrides the data file path** (`wt.py` and `mcp_server.py`), so
+exercise everything against a throwaway copy rather than the live,
+iCloud-synced source of truth:
+
+```bash
+WT_DATA_FILE=/tmp/wt-work.json python3 wt.py sync-sprints --all --dry-run
+```
+
+The harnesses swap `subprocess` for a guard that raises on any attribute access,
+so a missed stub fails loudly instead of reaching GitHub — **never** let a test
+run `gh issue create`/`close`; those writes are irreversible. Use `--dry-run`
+where available (`sync-sprints`, `close-recurrent`, `new-recurrent`). Because the
 data file is the single source of truth and syncs across Macs, avoid `save()`
 until you've confirmed the in-memory change is correct.
 
@@ -66,17 +88,17 @@ Single-file Python tools sharing one data file (`~/.workload_tracker.json`):
 > synced copy. If `ls` works but the file is still empty, it's a dataless iCloud
 > placeholder — force a download with `brctl download ~/WorkloadTracker/.workload_tracker.json`.
 
-- **tracker.py** — Textual TUI with modal screens for task editing and time logging. Uses reactive properties for filtering and a 1-second interval timer for live updates. Also hosts the Stream Deck / Hammerspoon HTTP bridge (localhost:7373) on a background `ThreadingHTTPServer` (`_BridgeHandler` + `_start_bridge_server`). Endpoints: `GET /status` (`active_timer` with `task_id`/`title`/`role`/`started_at`/`active_window_id` — the last being the Safari window id of the task's dedicated tab window, or `null` when there is none, consumed by the menu-bar monitor to draw a focus-aware border around the window — or the whole object is `null` when idle), `GET /tasks` (non-done, non-shadow picker list; each task carries `id`/`title`/`role`/`status` plus `last_logged_at` — epoch seconds of the task's most recent time-log entry via `task_last_logged_at()`, or `null` when nothing has been logged — consumed by the menu-bar monitor's "recently logged" column), `POST /timer/start` (`{task_id}`), `POST /timer/stop` (`{logged_minutes}`), plus the legacy GET `/timer/toggle`, `/log/<minutes>`, `/filter/<role>`, `/push/<task>`. Bridge requests mutate the live in-memory `self._data` via `call_from_thread` and refresh the UI, so external actions stay in sync with the TUI. A bridge **stop** goes through `_commit_active_timer()` — the same helper the TUI `t`-key stop uses — so it logs an identical `"Timer session"` entry, syncs GitHub hours, and runs Arc cleanup. A bridge **start** deliberately does *not* call `_arc_on_task_started` (no Arc space focus), since a remote/menu-bar start shouldn't reshuffle the Arc workspace; the TUI `t`-key start still focuses Arc. It *does* call `_browser_on_task_started` so the task's dedicated Safari window opens on a remote/menu-bar start (matching the TUI), since that's a per-task window rather than a workspace reshuffle. A client should treat a connection error as a distinct "tracker unreachable" state, separate from a `200` with `active_timer: null` (up but idle).
-- **wt.py** — Stateless CLI that reads/writes the JSON file directly. Commands: add, add-issue, list, start, stop, log, logs, edit-log, delete-log, split-log, merge-logs, notes, link, unlink, push, done, close-recurrent, new-recurrent, delete, rename, status, roles, arc, iterm, tabs (Safari task windows: `save`/`open`/`list`/`clear`/`close`), presence, config, calendar, report, sprint, set-sprint, split-sprint, set-repo, set-activity, set-type.
+- **tracker.py** — Textual TUI with modal screens for task editing and time logging. Uses reactive properties for filtering and a 1-second interval timer for live updates. Also hosts the Stream Deck / Hammerspoon HTTP bridge (localhost:7373) on a background `ThreadingHTTPServer` (`_BridgeHandler` + `_start_bridge_server`). Endpoints: `GET /status` (`active_timer` with `task_id`/`title`/`role`/`started_at`/`active_window_id` — the last being the Safari window id of the task's dedicated tab window, or `null` when there is none, consumed by the menu-bar monitor to draw a focus-aware border around the window — or the whole object is `null` when idle), `GET /tasks` (non-done picker list; each task carries `id`/`title`/`role`/`status` plus `last_logged_at` — epoch seconds of the task's most recent time-log entry via `task_last_logged_at()`, or `null` when nothing has been logged — consumed by the menu-bar monitor's "recently logged" column), `POST /timer/start` (`{task_id}`), `POST /timer/stop` (`{logged_minutes}`), plus the legacy GET `/timer/toggle`, `/log/<minutes>`, `/filter/<role>`, `/push/<task>`. Bridge requests mutate the live in-memory `self._data` via `call_from_thread` and refresh the UI, so external actions stay in sync with the TUI. A bridge **stop** goes through `_commit_active_timer()` — the same helper the TUI `t`-key stop uses — so it logs an identical `"Timer session"` entry, syncs GitHub hours, and runs Arc cleanup. A bridge **start** deliberately does *not* call `_arc_on_task_started` (no Arc space focus), since a remote/menu-bar start shouldn't reshuffle the Arc workspace; the TUI `t`-key start still focuses Arc. It *does* call `_browser_on_task_started` so the task's dedicated Safari window opens on a remote/menu-bar start (matching the TUI), since that's a per-task window rather than a workspace reshuffle. A client should treat a connection error as a distinct "tracker unreachable" state, separate from a `200` with `active_timer: null` (up but idle).
+- **wt.py** — Stateless CLI that reads/writes the JSON file directly. Commands: add, add-issue, list, start, stop, log, logs, edit-log, delete-log, split-log, merge-logs, notes, link, unlink, push, done, close-recurrent, new-recurrent, delete, rename, status, roles, arc, iterm, tabs (Safari task windows: `save`/`open`/`list`/`clear`/`close`), presence, config, calendar, report, sprint, set-sprint, sync-sprints (alias: split-sprint), set-repo, set-activity, set-type.
 - **idle_detector.py** — macOS idle detection module using `ioreg` to query HIDIdleTime.
-- **mcp_server.py** — MCP server enabling Claude to manage tasks directly. Tools: add_task, list_tasks, get_task, start_timer, stop_timer, log_time, list_logs, edit_log, delete_log, split_log, merge_logs, set_task_status, delete_task, rename_task, get_status, get_notes_path, link_github_issue, unlink_github_issue, push_task_to_github, view_github_issue, add_github_comment, list_roles, add_role, update_role, delete_role, set_task_repo, set_task_activity, set_task_type, setup_arc_space, get_arc_status, cleanup_task_tabs, sync_arc_folders, list_sprints, get_current_sprint_info, set_sprint, sprint_split, close_previous_recurrent_tasks.
+- **mcp_server.py** — MCP server enabling Claude to manage tasks directly. Tools: add_task, list_tasks, get_task, start_timer, stop_timer, log_time, list_logs, edit_log, delete_log, split_log, merge_logs, set_task_status, delete_task, rename_task, get_status, get_notes_path, link_github_issue, unlink_github_issue, push_task_to_github, view_github_issue, add_github_comment, list_roles, add_role, update_role, delete_role, set_task_repo, set_task_activity, set_task_type, setup_arc_space, get_arc_status, cleanup_task_tabs, sync_arc_folders, list_sprints, get_current_sprint_info, set_sprint, sync_task_sprints, close_previous_recurrent_tasks, report_time_range, create_task_from_issue, save_task_tabs, open_task_window, list_task_tabs, clear_task_tabs. (43 tools registered.)
 - **arc_browser.py** — Arc browser integration for task-based tab management. Hybrid AppleScript/JSON approach.
 - **iterm_manager.py** — iTerm2/tmux integration for task-based terminal sessions. Creates folders per task and manages tmux sessions with 3-pane layout.
 
 ### Data Model
 
 Plain JSON with three top-level keys:
-- `tasks[]` — Each task has: id, title, description, role_id, status, logs[], created_at, and optionally `github_issue`, `github_repo`, `activity`, `type`, `calendar_event_uid`, `sprint`, `sprint_id`, `cross_sprint_parent`
+- `tasks[]` — Each task has: id, title, description, role_id, status, logs[], created_at, and optionally `github_issue`, `github_repo`, `activity`, `type`, `calendar_event_uid`, `sprint_issues[]`, `start_sprint`/`start_sprint_id` (plus the legacy `sprint`/`sprint_id` mirror)
 - `active_timer` — `{task_id, started_at}` or null
 - `roles[]` — Each role has: id, label, color. Roles are pure categorization, user-configurable via `wt roles` commands. GitHub repo/activity/type are **per-task** fields (`wt set-repo/set-activity/set-type <task> ...`), not role fields.
 - `config.sprints_cache[]` — Persisted list of `{id, title, start_date, end_date, field_id}` written by `save_sprints_cache()` after the TUI fetches sprints from GitHub. Used by `get_sprint_date_range_for_task()` to avoid network calls (e.g. for the calendar modal's default range).
@@ -347,7 +369,7 @@ wt config calendar_id your.email@gmail.com  # Use specific calendar (default: pr
 
 Lookup goes through `resolve_event_to_task(data, event)` in `wt.py`, which:
 1. Reads the base name via `get_event_mapping()` (case- and whitespace-insensitive on event titles).
-2. Collects all non-shadow tasks whose `strip_sprint_suffix(title)` matches the base name (case-insensitive). Returns `None` if no candidates.
+2. Collects all tasks whose `strip_sprint_suffix(title)` matches the base name (case-insensitive). Returns `None` if no candidates.
 3. If the event's `start_date` resolves to a sprint via `get_cached_sprints()` → `find_sprint_for_date()` (with `get_all_sprints()` fallback), returns the candidate whose `sprint_id` matches.
 4. Otherwise sorts candidates (prefer non-done, then most recent sprint start_date, then `created_at`) and returns the first.
 
@@ -386,23 +408,23 @@ Linking an issue (`wt link`, MCP `link_github_issue`, `wt add-issue`, `create_ta
 2. If the task **has a repo**:
    - Task must have a linked GitHub issue
    - If no issue exists, user is prompted to create one (with local notes as body)
-   - **Cross-sprint auto-split**: if the task's logs span more than one sprint,
-     `close_task()` runs `split_cross_sprint_task()` *before* reporting hours, so
-     each prior sprint's hours land on their own shadow issue and only the most
-     recent sprint's hours are reported on the main issue (see "Cross-sprint
-     split workflow" below). Shadow tasks (`cross_sprint_parent` set) and
-     `recurrent` tasks are skipped. A failed split aborts the close (the task is
-     **not** marked done) so hours can't be mis-reported.
+   - **Auto-reconcile**: `close_task()` runs `reconcile_task_sprints()` *before*
+     reporting hours, so each prior sprint's hours land on that sprint's own
+     issue and only the current sprint's hours go on the current binding (see
+     "Reconcile workflow" below). It runs unconditionally — reconcile is
+     idempotent, so there's no "does this span sprints?" gate any more.
+     `recurrent` tasks are skipped. A failed reconcile aborts the close (the task
+     is **not** marked done) so hours can't be mis-reported.
    - Issue is added to the configured GitHub project (if configured)
    - Project item is updated with Status=Done, the task's Activity/Type (when
-     set), and the **sprint-filtered** hours (`task_logged_mins_for_sprint`),
+     set), and the **sprint-filtered** hours (`task_reportable_mins`),
      not the task's total
    - **GitHub issue is automatically closed**
 
-   The CLI `wt done` prints the split breakdown (each `Sprint N → Xh (issue)`
-   line plus `Main task kept on Sprint M`) and the sprint-filtered hours synced.
-   `close_task()` returns `split_performed: bool` and `split_result: dict`
-   alongside the existing keys.
+   The CLI `wt done` renders the reconcile outcome (which issues were created,
+   re-pointed, had hours updated, or closed) plus the sprint-filtered hours
+   synced. `close_task()` returns `reconcile_result: dict` alongside the existing
+   keys; `split_performed`/`split_result` are still populated for older callers.
 
 **Configuration:**
 
@@ -465,7 +487,6 @@ fields — Status=Done, Hours, Activity, Sprint, Type — and closes the issue).
 **A task qualifies only if it:**
 - has `status == "recurrent"`,
 - has a linked `github_issue` (tasks without one are skipped entirely),
-- is not a cross-sprint shadow (`cross_sprint_parent` unset), and
 - has a `sprint_id` matching a target sprint.
 
 **Scope (default vs. opt-in):** by default only the sprint *immediately before*
@@ -508,7 +529,7 @@ status alone. A source task in the target sprint(s) is treated as recurring when
   this is the recurring-task naming convention and is the only signal for a
   series whose copies are *all* closed (e.g. `General Demo Kit maintenance -
   Sprint 100`); **or**
-- its base name (`strip_sprint_suffix(title)`) matches some non-shadow task
+- its base name (`strip_sprint_suffix(title)`) matches some task
   anywhere that currently has `status == "recurrent"` (covers recurring tasks
   without the suffix).
 
@@ -549,67 +570,107 @@ wt new-recurrent --dry-run       # preview; combine with --all-previous
 
 ### Sprint Tracking
 
-Tasks are assigned to sprints (GitHub Project iterations). Sprints are auto-assigned on task creation.
+A task is **not assigned to a sprint**. It has a *starting* sprint (the sprint
+of its first log) and one **GitHub issue binding per sprint** it has time in.
+Which sprint any minute of work belongs to is derived from the log's timestamp.
+There are **no shadow tasks** — see `docs/plan-sprint-bindings.md` for the full
+design and the migration away from them.
 
 **Task fields:**
-- `sprint` — Sprint title for display (e.g., "Sprint 43")
-- `sprint_id` — GitHub iteration ID for API calls
-- `cross_sprint_parent` — If set, this is a shadow task created by cross-sprint split (hidden from views)
+- `sprint_issues[]` — the bindings, one per sprint:
+  `{sprint_id, sprint, issue, state, hours_synced, synced_at, created_at}`.
+  `issue` is always a full `owner/repo#n` ref (a task's issues can live in
+  different repos). `state` is the *issue's* open/closed state, independent of
+  the task's `status`. `hours_synced` caches what GitHub was last told so a
+  reconcile can skip no-op API calls — it is never a source of truth; hours are
+  always recomputed from `logs`.
+- `start_sprint_id` / `start_sprint` — derived from the earliest log, then
+  frozen, so a later log edit doesn't silently rewrite history.
+- `sprint` / `sprint_id` — **legacy**, still written and read as a mirror of the
+  current binding. Retiring them is a later, coordinated phase; don't add new
+  readers.
+- `cross_sprint_parent` — **gone.** `_migrate_shadows_to_bindings()` converts
+  any task carrying it into a binding on its parent and deletes it. That sweep
+  runs on *every* `load()`, not just the first, so an older `wt.py` syncing via
+  iCloud from another Mac can't reintroduce one.
+
+**"Current" issue** is derived, not stored: the binding for the current sprint,
+else the binding with the latest sprint start date, else the legacy
+`github_issue`. Always read it via `task_current_issue(task, data)` — never
+`task["github_issue"]` directly.
 
 **CLI commands:**
 ```bash
-wt sprint                           # Show current sprint + tasks by sprint
-wt set-sprint <task> <sprint>       # Set/change sprint for a task
-wt set-sprint <task> none           # Clear sprint
-wt split-sprint <task>              # Split cross-sprint task into per-sprint shadow tasks
+wt sprint                           # Tasks grouped by the current sprint's bindings
+wt set-sprint <task> <sprint>       # Correct the *start* sprint (rare)
+wt set-sprint <task> none           # Clear it, so it re-derives from the logs
+wt sync-sprints <task>              # Reconcile one task's bindings + issues
+wt sync-sprints --all --dry-run     # Preview across every non-recurrent task
+wt sync-sprints --all               # Sync hours + close ended sprints
+wt sync-sprints --all --create-issues   # ...and mint missing past-sprint issues
 wt add "title" --sprint "Sprint 43" # Create task with specific sprint
 wt add "title" --sprint none        # Create task without sprint
 ```
 
+`wt split-sprint` still works as a deprecated alias for `wt sync-sprints`.
+
+**Two safety rules baked into `sync-sprints`:**
+- `--all` **does not create issues** unless `--create-issues` is passed. A
+  blanket run over a long history can want to mint a couple dozen issues for
+  sprints predating this workflow; those show as
+  `SKIP … re-run with --create-issues` rather than being silently bound
+  issue-less. It always prints an itemised plan and prompts `Proceed? [Y/n]`
+  (`--yes` to skip, `--dry-run` to print and exit).
+- **`recurrent` tasks are skipped** and reported as such. They're still one task
+  object per sprint, handled by `close-recurrent` / `new-recurrent`; unifying
+  them into a single task with one binding per sprint is a later phase.
+
 **Three task lifecycle patterns:**
-1. **Single-sprint**: Fully contained in one sprint. Auto-assigned, no special handling.
-2. **Recurrent**: Long-lived tasks that intentionally span sprints (e.g. "Slack questions", on-call). Marked with `status="recurrent"`, displayed in the dedicated bottom table in the TUI, and skipped by cross-sprint detection. Alternatively, the user can still create one regular task per sprint manually.
-3. **Cross-sprint**: A non-recurrent task that ended up with logs in multiple sprints. `split-sprint` or close workflow creates shadow tasks.
+1. **Single-sprint**: fully contained in one sprint. One binding, no special handling.
+2. **Recurrent**: long-lived tasks that intentionally span sprints (e.g. "Slack questions", on-call). `status="recurrent"`, shown in the TUI's bottom table, skipped by reconcile.
+3. **Cross-sprint**: a non-recurrent task with logs in several sprints. It stays **one task object** and grows a binding per sprint.
 
-**Cross-sprint split workflow:**
-When a task has logs in multiple sprints (detected via log timestamps):
-1. For each **previous sprint**: creates a shadow task + GH issue with that sprint's hours, closes it
-2. **Main task**: updated to most recent sprint with only that sprint's hours on GH
-3. Shadow tasks have `cross_sprint_parent` field → hidden from all default views
-4. Original task keeps ALL logs (source of truth)
+**Reconcile workflow** (`reconcile_task_sprints`, replaces the old split):
+a pure diff between derived target state and existing bindings —
+1. Bucket logs by sprint; drop zero-total sprints.
+2. Target set = {sprints with time} ∪ {current sprint, if the task is open}.
+   That second term is why the old **0-minute "rollover marker" log hack is
+   unnecessary** — an open task always has a landing place for new work.
+3. Create a binding (and issue, if the task has a `github_repo`) for each
+   missing target sprint. New issues are for *past* sprints and keep the
+   ` (Sprint N)` title suffix.
+4. Set each binding's Hours, but only when it differs from `hours_synced`.
+5. Close any binding whose sprint has ended (Status=Done + `gh issue close`).
+6. Never delete a binding. Never touch `logs`.
 
-**Triggers:** the split runs from three places — the explicit `wt split-sprint`
-command, the TUI split action, and **automatically inside `close_task()`** when
-you close a multi-sprint task (see "Close Workflow" above). The close-time split
-skips shadow tasks (`cross_sprint_parent` set) and `recurrent` tasks, and aborts
-the close if the split fails.
+**Idempotency is structural**, not a guard: re-running diffs against a derived
+target set, so a second `wt sync-sprints` or `wt done` reports "Nothing to do".
+`dry_run=True` is write-free by construction (the planner is separate from the
+executor), so it makes no GitHub calls and mutates nothing.
 
-**Idempotency:** the main task keeps ALL its logs (step 4), so its
-`sprint_summary_for_task()` still spans multiple sprints *after* a split — a
-naive re-run would re-detect the same previous sprints and create duplicate
-shadow tasks/issues. `split_cross_sprint_task()` guards against this: before the
-per-sprint loop it collects the `sprint_id`s of existing shadows
-(`cross_sprint_parent == task["id"]`) and skips any previous sprint that already
-has one (recording a `{"skipped": "shadow already exists"}` result entry instead
-of creating a duplicate). So both `wt split-sprint` and a second `wt done` are
-safe to re-run; only sprints without a shadow get one, and the main-task
-re-point + hours-sync are no-ops when nothing changed. The `wt split-sprint`
-preview reflects this — already-split sprints are marked `(already split)`, the
-"will create N shadow task(s)" count excludes them, and it short-circuits with
-"All previous sprints are already split. Nothing to do." when none remain.
-
-**Auto-detection:** TUI checks for cross-sprint tasks on mount and shows a notification.
+**Triggers:** `wt sync-sprints`, the TUI reconcile action, and automatically
+inside `close_task()` on every close. Recurrent tasks are excluded; a failed
+reconcile aborts the close so hours can't be mis-reported.
 
 **Key functions in wt.py:**
 - `get_all_sprints(data)` — All sprint iterations from GitHub Project (GraphQL); no caching, network call every time
 - `get_current_sprint(data)` — Current sprint based on today's date
 - `find_sprint_for_date(sprints, dt)` — Find which sprint a date falls in
-- `sprint_summary_for_task(task, sprints)` — Per-sprint time breakdown
-- `split_cross_sprint_task(task, data, save_callback)` — Execute the split
+- `task_sprints_with_time(task, sprints)` — Per-sprint time breakdown, excluding zero-minute sprints. Replaces `sprint_summary_for_task` (kept as a deprecated shim). **Sorts on the `start_date` date object**, not the camelCase `startDate` key that only `get_all_sprints()` emits — passing cached sprints to the old function sorted every entry by `""`.
+- `reconcile_task_sprints(task, data, sprints, *, create_issues=True, close_past=True, sync_hours=True, dry_run=False, save_callback=None, progress_callback=None)` — the reconcile. `split_cross_sprint_task` is a deprecated wrapper.
+- `task_mins_for_sprint(task, sprint_id, sprints)` — minutes in one sprint, from the logs. No "unknown sprint → task total" fallback.
+- `task_reportable_mins(task, data, sprints)` — what to report to GitHub: resolves the sprint from the bindings, falling back to the task total only when *no* sprint resolves, so an unreachable `gh` never under-reports 0.
+- `task_current_issue` / `current_binding` / `task_binding_for_sprint` / `task_issue_refs` / `set_task_current_issue` / `clear_task_current_issue` — the issue accessor layer.
 - `save_sprints_cache(data, sprints)` / `get_cached_sprints(data)` — Persist sprint list (id, title, start_date, end_date, field_id) to `data["config"]["sprints_cache"]` so consumers can resolve sprint dates without hitting GitHub. Caller must `save(data)` after writing.
-- `get_sprint_date_range_for_task(task, data)` — Resolves `(sprint_dict, start_date, end_date)` for a task's sprint context. Looks up the task's `sprint_id` first, falls back to current sprint; tries the persisted cache before the network.
+- `get_sprint_date_range_for_task(task, data)` — Resolves `(sprint_dict, start_date, end_date)` for a task's sprint context. Tries the persisted cache before the network.
 
-**MCP tools:** `list_sprints`, `get_current_sprint_info`, `set_sprint`, `sprint_split`
+**MCP tools:** `list_sprints`, `get_current_sprint_info`, `set_sprint`, `sync_task_sprints`
+
+**Verification:** `python3 tools/check_invariants.py <data.json> [baseline.json]`
+asserts no shadows survive, every binding issue is a full `owner/repo#n`, no two
+bindings share a sprint, and (against a `tools/baseline.py` snapshot) that total
+minutes and log count are unchanged. Sprints with logged time and no binding are
+**warnings**, not failures — reconcile is what closes that gap.
 
 ### GitHub CLI (gh) Reference
 
@@ -791,8 +852,11 @@ Authoritative signatures (use these instead of guessing — see live values via 
 - `save_sprints_cache(data, sprints) -> None` — caller must `save(data)`
 - `get_cached_sprints(data) -> list[dict]` — reads `data["config"]["sprints_cache"]`
 - `get_sprint_date_range_for_task(task, data) -> (sprint, start, end) | None` — cache-first, falls back to live
-- `sprint_summary_for_task(task, sprints) -> list[dict]`
-- `split_cross_sprint_task(task, data, save_callback, all_sprints=None, progress_callback=None) -> dict`
+- `sprint_summary_for_task(task, sprints) -> list[dict]` — *deprecated shim*, zero-minute-inclusive
+- `reconcile_task_sprints(task, data, sprints, *, create_issues=True, close_past=True, sync_hours=True, dry_run=False, save_callback=None, progress_callback=None) -> dict` — replaces `split_cross_sprint_task` (kept as a deprecated wrapper). `dry_run` is write-free by construction.
+- `task_current_issue(task, data=None) -> str | None` — **use this instead of `task["github_issue"]`**; offline, never a network call
+- `task_mins_for_sprint(task, sprint_id, sprints) -> float` / `task_reportable_mins(task, data, sprints) -> float`
+- `task_sprints_with_time(task, sprints) -> list[dict]` — replaces `sprint_summary_for_task`
 
 **Calendar integration**
 - `get_calendar_events(days_back=1, calendar_id="primary", start_date=None, end_date=None) -> list[dict]` — event dict has `uid, title, start_date (ts), end_date (ts), duration_mins, calendar_name`
@@ -925,22 +989,24 @@ wt.save(data)
 - Don't write to `data["config"]["sprints_cache"]` by hand — use `save_sprints_cache(data, sprints)` so the entry shape stays correct (ISO date strings).
 - Don't add new task statuses without updating `PROJECT_STATUS_MAP` (`wt.py`) — missing entries cause silent sync no-ops.
 - Don't bypass `resolve_event_to_task()` in new code that logs a calendar event to a mapped task — manual `resolve_task_by_id(get_event_mapping(...))` skips the sprint-aware routing.
-- When reporting hours to a GitHub issue, use the **sprint-filtered** total (`task_logged_mins_for_sprint(task, all_sprints)`), not `task_logged_mins(task)`. A cross-sprint task keeps *all* its logs locally as the source of truth while its per-sprint hours live on the shadow tasks' issues; reporting the task total double-counts. Both `sync_project_hours()` and `close_task()` (`wt.py`) now use the sprint-filtered value — keep any new GitHub-hours path consistent with them.
+- When reporting hours to a GitHub issue, use the **sprint-filtered** total (`task_reportable_mins(task, data, sprints)`), never `task_logged_mins(task)`. A cross-sprint task keeps *all* its logs on one object as the source of truth while its per-sprint hours live on separate per-sprint issues; reporting the task total double-counts. `sync_project_hours()`, `close_task()` and `reconcile_task_sprints()` all use the sprint-filtered value — keep any new GitHub-hours path consistent.
+- Don't read `task["github_issue"]` directly — use `task_current_issue(task, data)`. A task has one issue *per sprint*; the raw key is a legacy mirror of the current one.
+- Don't reintroduce a "does this task span sprints?" gate before reconciling. Reconcile is idempotent by construction; gates were how the old code needed 0-minute marker logs.
+- Don't run an all-tasks reconcile with issue creation enabled without showing the plan first — it can mint dozens of issues for sprints predating this workflow.
 
-### Cross-sprint tasks (how the split lays out)
+### Cross-sprint tasks (how the bindings lay out)
 
-A non-recurrent task worked across several sprints is split (via `split-sprint`,
-the TUI split action, or **automatically when you close it** — see "Close
-Workflow") into one **shadow task per previous sprint** (`cross_sprint_parent`
-set, hidden from default views, each with its own closed GH issue carrying that
-sprint's hours) plus the **original/main task**, which keeps **every** log
-(source of truth) and is re-pointed to the *most recent* sprint.
+A non-recurrent task worked across several sprints stays **one task object**. It
+keeps **every** log (source of truth) and grows one entry in `sprint_issues[]`
+per sprint it has time in — each with its own GitHub issue carrying only that
+sprint's hours, closed once the sprint ends. Its long-lived original issue is
+carried forward as the *current* binding.
 
-Because `close_task()` now splits on the fly, you usually just run `wt done
-<task>` and it does the right thing: prior-sprint shadows are created + closed,
-the main issue is re-pointed to the latest sprint with only that sprint's hours,
-and the task is marked done. To audit afterwards, check that
-`bucket_logs_by_sprint(task, sprints)` matches each shadow's logged hours and
-that the main GH issue shows only its current-sprint portion. The split is
-skipped for `recurrent` tasks and already-split shadows, and a split failure
-aborts the close (task stays open) so hours are never mis-reported.
+Because `close_task()` reconciles on the fly, you usually just run `wt done
+<task>`: past-sprint issues are created + closed, the current binding is
+carried to the latest sprint with only that sprint's hours, and the task is
+marked done. To audit afterwards, compare `bucket_logs_by_sprint(task, sprints)`
+against each binding's `hours_synced` — or just run
+`tools/check_invariants.py`, which asserts exactly that. Reconcile is skipped for
+`recurrent` tasks, and a failure aborts the close (task stays open) so hours are
+never mis-reported.

--- a/_wt
+++ b/_wt
@@ -77,8 +77,9 @@ _wt() {
         'split-log:Split a log entry'
         'merge-logs:Merge two log entries'
         'sprint:Show sprint info'
-        'set-sprint:Set sprint for a task'
-        'split-sprint:Split cross-sprint task'
+        'set-sprint:Correct the sprint a task started in'
+        'sync-sprints:Reconcile per-sprint GitHub issues with a task'"'"'s logs'
+        'split-sprint:Deprecated alias for sync-sprints'
         'set-repo:Set GitHub repo for a task'
         'set-activity:Set GitHub Project activity for a task'
         'set-type:Set GitHub Project type for a task'
@@ -103,14 +104,17 @@ for t in data.get('tasks', []):
             compadd -Q "${tasks[@]}"
             ;;
         unlink)
-            # Only show tasks that have github_issue
+            # Only show tasks linked to an issue — via a sprint_issues binding or
+            # the legacy github_issue field.
             local -a tasks
             tasks=("${(@f)$(python3 -c "
 import json
 from pathlib import Path
 data = json.loads((Path.home() / '.workload_tracker.json').read_text())
 for t in data.get('tasks', []):
-    if t.get('github_issue'):
+    linked = t.get('github_issue') or any(
+        b.get('issue') for b in (t.get('sprint_issues') or []))
+    if linked:
         print(t['title'])
 " 2>/dev/null)}")
             compadd -Q "${tasks[@]}"
@@ -405,7 +409,7 @@ for t in data.get('tasks', []):
                 _describe -t options 'presence option' options
             fi
             ;;
-        rename|mv|logs|edit-log|delete-log|split-log|merge-logs|split-sprint)
+        rename|mv|logs|edit-log|delete-log|split-log|merge-logs)
             local -a tasks
             tasks=("${(@f)$(python3 -c "
 import json
@@ -416,20 +420,35 @@ for t in data.get('tasks', []):
 " 2>/dev/null)}")
             compadd -Q "${tasks[@]}"
             ;;
+        sync-sprints|split-sprint)
+            # Flags first, then task titles. --all is mutually exclusive with a
+            # task argument, and --create-issues only matters alongside --all.
+            if [[ "${words[CURRENT]}" == -* ]]; then
+                _arguments \
+                    '--all[Reconcile every non-recurrent task]' \
+                    '--create-issues[Allow minting new past-sprint issues]' \
+                    '--dry-run[Print the plan and exit]' \
+                    '-n[Print the plan and exit]' \
+                    '--yes[Skip the confirmation prompt]' \
+                    '-y[Skip the confirmation prompt]'
+            else
+                _wt_complete_tasks
+            fi
+            ;;
         set-sprint)
             if (( CURRENT == 3 )); then
-                # Complete task names
-                local -a tasks
-                tasks=("${(@f)$(python3 -c "
+                _wt_complete_tasks
+            elif (( CURRENT == 4 )); then
+                # Complete sprint titles from the cache, plus "none" to clear.
+                local -a sprints
+                sprints=("${(@f)$(python3 -c "
 import json
 from pathlib import Path
 data = json.loads((Path.home() / '.workload_tracker.json').read_text())
-for t in data.get('tasks', []):
-    print(t['title'])
+for s in data.get('config', {}).get('sprints_cache', []):
+    print(s['title'])
 " 2>/dev/null)}")
-                compadd -Q "${tasks[@]}"
-            elif (( CURRENT == 4 )); then
-                # Complete sprint names (includes "none")
+                compadd -Q "${sprints[@]}"
                 compadd "none"
             fi
             ;;

--- a/docs/plan-sprint-bindings.md
+++ b/docs/plan-sprint-bindings.md
@@ -1,0 +1,394 @@
+# Plan: replace shadow tasks with per-sprint issue bindings
+
+**Status:** proposal, not implemented
+**Date:** 2026-07-30 (Sprint 105)
+**Goal:** one task object per unit of work, forever. Sprint attribution derived
+from log timestamps. GitHub issues tracked as a list of per-sprint bindings
+instead of duplicate "shadow" task objects.
+
+---
+
+## 1. What's wrong with the current model
+
+### 1.1 Shadow tasks duplicate data, lossily
+
+`split_cross_sprint_task()` creates one shadow task per previous sprint. The
+shadow does **not** carry the real logs — it gets a single synthetic log:
+
+```json
+{"id": "…", "minutes": 314.09,
+ "note": "Sprint split: 5h 14m from IRON Infusion",
+ "at": 1781738865}          // ← the split time, NOT when the work happened
+```
+
+The real logs stay on the parent. So the shadow's own log is dated in the
+*wrong sprint* (whenever the split ran), and its per-log detail is gone.
+
+Consequence: **every** aggregation over `data["tasks"]` must filter shadows out
+or it double-counts. In `wt.py` that's 6 filter sites (`logs_in_date_range`,
+`cmd_list`, `cmd_sprint`, `resolve_event_to_task`,
+`find_recurrent_tasks_to_close`, `find_recurrent_tasks_to_recreate`) plus 3
+skip/idempotency guards; in `tracker.py` 3 filters (board render, cross-sprint
+detector, bridge task picker) plus the `TaskModal` field-copy list; in
+`mcp_server.py` 1 filter (`list_tasks`). Each one is a place where a future
+feature silently double-counts hours.
+
+Current data: **91 tasks, 12 of them shadows** (13%).
+
+### 1.2 `sprint_id` is three fields wearing one hat
+
+`task["sprint_id"]` simultaneously means:
+
+1. **Board grouping** — which sprint column the task shows under (`wt sprint`).
+2. **Hours filter** — which sprint's minutes to report to GitHub
+   (`task_logged_mins_for_sprint`).
+3. **GH Project iteration** — the value written to the Sprint field
+   (`update_project_sprint`).
+
+When work continues past a sprint boundary these diverge, and the code resolves
+it by **mutating `sprint_id` forward** (`split_cross_sprint_task` step "Update
+main task sprint to most recent"). That destroys "when did this task start",
+which is information Carlos actually wants.
+
+### 1.3 The marker-log hack
+
+Because rollover is implemented as "mutate `sprint_id` to the most recent sprint
+*that has logs*", a task worked only in the closed sprint rolls **backwards**.
+The documented workaround (`.claude/skills/close-sprint/SKILL.md` step 3, case 2)
+is to append a **0-minute log dated now** to fake presence in the new sprint:
+
+```python
+t["logs"].append({"id": wt.uid(), "minutes": 0,
+                  "note": "Sprint rollover marker: work continues in Sprint <current>",
+                  "at": time.time()})
+```
+
+There are **3 such marker logs in the live data** right now (visible as
+`Sprint 104=0m` on `Implement Sigil instrumentation…`, `CI Check to read Demo
+Blocks…`, `Document current FE platform`). The skill also warns you must *keep*
+them or a later `wt done` double-counts. This is a data-model deficiency
+papered over with a ritual.
+
+### 1.4 Idempotency is bolted on
+
+The main task keeps all logs, so a re-split re-detects the same previous
+sprints. `split_cross_sprint_task` guards with "does a shadow already exist for
+this `sprint_id`?" and `cmd_split_sprint` mirrors the same set logic in its
+preview. Two copies of the same guard, both load-bearing.
+
+### 1.5 Notes / tabs / terminal state fragment
+
+`notes_path(task_id)` is keyed on task id. A shadow gets a **fresh id** → no
+notes, no tabs, no iTerm folder. Per-sprint recurrent copies each get their own
+id too. Continuous work therefore scatters its local context across N task
+objects.
+
+### 1.6 Recurrent tasks are a second, parallel solution to the same problem
+
+Recurrent work spanning sprints is handled by *manually cloning the task per
+sprint* with a ` - Sprint NN` title suffix, plus a whole subsystem:
+`close-recurrent`, `new-recurrent`, `SPRINT_SUFFIX_RE`, `strip_sprint_suffix`,
+`_same_recurrent_series` (prefix-boundary matching to tolerate title drift), and
+calendar mappings keyed on *base names* rather than task ids precisely because
+titles carry sprint suffixes. That is a lot of machinery to express "this work
+continues into the next sprint" — the same thing the split machinery expresses a
+different way.
+
+And it leaks: `Ana 1:1 calls - casanabria - Sprint 104` currently holds 38m of
+**Sprint 105** time, and `Ad-hoc Slack Questions - Sprint 104` holds 80m of
+Sprint 105 time. Step 0 of the close-sprint skill exists to hand-repair this.
+
+### 1.7 Latent bug to fix while we're in here
+
+`sprint_summary_for_task()` sorts by `x["start_date"]` where that value comes
+from `s.get("startDate", "")` — the **camelCase** key, which only
+`get_all_sprints()` produces. `get_cached_sprints()` produces `start_date` only.
+So calling `sprint_summary_for_task(task, get_cached_sprints(data))` sorts every
+entry by `""`, making `summary[-1]` ("most recent sprint") *whatever sprint the
+last-encountered log happened to fall in*. All current callers pass
+`get_all_sprints()` output, so this is latent rather than live — but it's a
+loaded gun aimed at "which sprint stays on the main task".
+
+---
+
+## 2. Target model
+
+### 2.1 Schema
+
+Per task, replacing `sprint` / `sprint_id` / `cross_sprint_parent`:
+
+```json
+{
+  "id": "20260403085012abcd",
+  "title": "IRON Infusion",
+  "role_id": "iron infusion",
+  "status": "done",
+  "github_repo": "grafana/field-eng",
+  "activity": "…",
+  "type": "…",
+
+  "start_sprint_id": "s98",
+  "start_sprint": "Sprint 98",
+
+  "logs": [ /* unchanged — the single source of truth */ ],
+
+  "sprint_issues": [
+    {"sprint_id": "s98",  "sprint": "Sprint 98",  "issue": "grafana/field-eng#5826",
+     "state": "closed", "hours_synced": 5.25,  "synced_at": 1781738865, "created_at": 1781738860},
+    {"sprint_id": "s99",  "sprint": "Sprint 99",  "issue": "grafana/field-eng#5827",
+     "state": "closed", "hours_synced": 7.75,  "synced_at": 1781738876, "created_at": 1781738870},
+    {"sprint_id": "s100", "sprint": "Sprint 100", "issue": "grafana/field-eng#5828",
+     "state": "closed", "hours_synced": 38.25, "synced_at": 1781738886, "created_at": 1781738880},
+    {"sprint_id": "s101", "sprint": "Sprint 101", "issue": "grafana/field-eng#5829",
+     "state": "closed", "hours_synced": 11.75, "synced_at": 1781738897, "created_at": 1781738890},
+    {"sprint_id": "s102", "sprint": "Sprint 102", "issue": "grafana/field-eng#5238",
+     "state": "open",   "hours_synced": 3.0,   "synced_at": 1781738900, "created_at": 1712181070}
+  ]
+}
+```
+
+Notes on the shape:
+
+- **One list, not `current_issue` + `previous_issues[]`.** Two fields would need
+  dual writes and can drift. "Current" is *derived*: the binding whose
+  `sprint_id` is the current sprint, else the binding with the latest sprint
+  `start_date`. A `task_current_issue(task)` accessor is the only thing the
+  ~148 existing `github_issue` references (49 `wt.py` + 53 `tracker.py` +
+  46 `mcp_server.py`) need to route through.
+- **`issue` is always a full `owner/repo#n` ref.** Non-negotiable: the live data
+  already has a task (`CI Check to read Demo Blocks…`) whose parent issue is in
+  `grafana/appenv` while its shadow issues are in
+  `grafana/field-eng-demo-kit`. A bare number would corrupt these.
+- **`start_sprint*` is derived-then-frozen** — computed from the earliest log
+  the first time it's needed, then left alone (so a corrective log edit doesn't
+  silently rewrite history). `wt set-sprint` becomes "correct the start sprint",
+  a rare manual override.
+- **`hours_synced` / `synced_at` are a cache of what GitHub was last told**, so
+  a reconcile can skip no-op API calls. Never a source of truth — hours are
+  always recomputable from `logs`.
+- `state` is the *issue's* open/closed state, independent of the task's
+  `status`. `PROJECT_STATUS_MAP` applies to the current binding only; past
+  bindings are always `Done`.
+
+### 2.2 Derived accessors (new, in `wt.py`)
+
+```python
+task_sprint_bindings(task, sprints) -> list[dict]   # sorted by sprint start_date
+task_current_issue(task) -> str | None              # replaces task["github_issue"] reads
+task_binding_for_sprint(task, sprint_id) -> dict | None
+task_start_sprint(task, sprints) -> dict | None      # frozen, or derived from earliest log
+task_mins_for_sprint(task, sprint_id, sprints) -> float   # from logs; replaces task_logged_mins_for_sprint
+task_sprints_with_time(task, sprints) -> list[dict]  # replaces sprint_summary_for_task
+```
+
+`task_mins_for_sprint` deliberately drops the current
+`task_logged_mins_for_sprint` fallback of "no `sprint_id` → return the task
+total", which silently over-reports for any task whose sprint can't be resolved.
+New behaviour: unresolvable → `0.0` for that sprint, and the minutes land in an
+explicit `unassigned` bucket that `wt sprint`/`wt report` can surface.
+
+### 2.3 One reconcile function replaces the split
+
+```python
+def reconcile_task_sprints(task, data, sprints, *,
+                           create_issues=True, close_past=True,
+                           sync_hours=True, dry_run=False,
+                           save_callback=None, progress_callback=None) -> dict
+```
+
+Algorithm — pure function of `logs` + `sprints` + existing bindings:
+
+1. Bucket logs by sprint (`bucket_logs_by_sprint`). Drop zero-total sprints.
+2. Target binding set = {sprints with time} ∪ {current sprint, if the task is
+   open}. The second term is what removes the need for marker logs: an open
+   task always has a place for new work to land, whether or not any minutes
+   exist yet.
+3. For each target sprint with no binding, create one. Create its GH issue if
+   the task has a `github_repo`.
+4. For each binding, compute `hours = mins_to_quarter_hours(mins for that
+   sprint)`; push to the Project only if it differs from `hours_synced`.
+5. For each binding whose sprint has ended: set Status=Done, close the issue,
+   `state = "closed"`. (`close_past=False` for a preview/read-only pass.)
+6. Never delete a binding. Never touch `logs`.
+
+Properties this buys for free:
+
+- **Idempotent by construction.** Re-running is a diff against a derived target
+  set, so both idempotency guards (§1.4) delete themselves.
+- **No marker logs** (step 2).
+- **No shadow filtering** — there is nothing to filter (§1.1).
+- **Self-healing.** Misfiled logs (§1.6) fix themselves: move the log, re-run
+  reconcile, both sprints' hours are recomputed from scratch. Today that's a
+  hand-written script in the skill's step 0.
+
+### 2.4 Which issue is "current"? (decision point)
+
+Two directions, both eliminate shadow tasks:
+
+**Option A — carry the original forward (recommended).** The task's original
+issue stays the long-lived "current" one; crossing a boundary mints a *new*
+issue for the **sprint that just ended**, titled `Task (Sprint N)`, closed with
+that sprint's hours. The original's Sprint field moves forward and its Hours is
+rewritten to the new sprint's total.
+
+This is **exactly what happens on GitHub today.** The change is purely local:
+`sprint_issues[]` replaces shadow task objects. That makes the migration
+verifiable in the strongest possible way — *GitHub state should not change at
+all*, so any diff is a bug. It also keeps discussion and notes on one
+long-lived issue, and matches Carlos's description ("current GH issue = the one
+in the current sprint; previous issues created as the task crossed boundaries").
+
+**Option B — roll forward.** The original issue stays pinned to its start
+sprint and is closed when that sprint ends; each new sprint mints a fresh
+"current" issue. Cleaner in principle (an issue's Sprint and Hours never change
+after its sprint closes; closing at sprint end is honest) but it reverses
+today's GitHub-side behaviour, fragments discussion across issues, and needs a
+backlink chain (`Continues from #X` / `Continued in #Y`) to stay navigable.
+
+**Recommendation: Option A.** Ship the local restructuring with zero GitHub
+behaviour change; revisit B later as an independent decision if the moving
+Sprint/Hours fields on long-lived issues become annoying.
+
+---
+
+## 3. What this changes for the user
+
+| Today | After |
+|---|---|
+| `wt split-sprint <task>` + marker-log ritual | `wt sync-sprints [<task>]` — idempotent, no ritual |
+| close-sprint skill steps 3 **and** 4 (split, then re-point strays) | one `wt sync-sprints --all` |
+| `wt list --shadows` | flag deleted (nothing to hide) |
+| `wt set-sprint` = re-point a task forward | = correct a wrong start sprint (rare) |
+| `wt sprint` groups by mutable `task["sprint"]` | groups by current sprint's bindings; shows "started Sprint N" for carry-overs |
+| `wt report --sprint` needs a shadow filter to be correct | authoritative from logs, no filter |
+| 12 duplicate task objects in the board's blind spot | 0 |
+
+TUI: the cross-sprint "use `wt split-sprint`" nag notification goes away —
+reconcile is no longer something the user has to be told to run.
+
+---
+
+## 4. Implementation phases
+
+### Phase 0 — Backup and pin the GitHub baseline
+
+1. `cp ~/.workload_tracker.json ~/workload_tracker.backup.$(date +%F).json`
+2. Snapshot GH Project state for all 79 linked issues (Sprint, Hours, Status)
+   into a JSON file. Under Option A this is the assertion target: after
+   migration + a full reconcile, this snapshot must be **unchanged**.
+3. Record local invariants: total log minutes per task, count of tasks, count
+   of logs.
+
+### Phase 1 — Schema, accessors, migration (no behaviour change)
+
+- Add the accessors from §2.2. Every one falls back to legacy fields, so
+  nothing breaks.
+- `_migrate_shadows_to_bindings(data)`, run from `load()` behind
+  `config.sprint_bindings_migrated` — same pattern as the existing
+  `_migrate_role_github_fields` / `config.role_fields_migrated_to_tasks`:
+  1. For each shadow (`cross_sprint_parent` set), find the parent. Append
+     `{sprint_id, sprint, issue: shadow["github_issue"], state: "closed",
+     hours_synced: mins_to_quarter_hours(shadow marker minutes)}` to the
+     parent's `sprint_issues`.
+  2. Append the parent's own `{sprint_id, github_issue, state: open|closed}`
+     binding.
+  3. Set `start_sprint_id`/`start_sprint` from the parent's earliest log.
+  4. **Delete the shadow task object.** Do *not* merge its marker log into the
+     parent — the parent already holds the real logs; merging double-counts.
+  5. Log an orphan report if a shadow's parent is missing (currently: none).
+- Because the file syncs via iCloud, keep the migration idempotent and also
+  **strip re-introduced shadows on sight** (an older `wt.py` on the other Mac
+  could recreate one), mirroring how `_migrate_role_github_fields` keeps
+  stripping legacy role keys.
+- Verify: 91 → 79 tasks, 12 shadows → 0, per-task log minutes identical,
+  bindings' `hours_synced` matching the shadows' marker minutes.
+
+### Phase 2 — `reconcile_task_sprints()`
+
+- Implement §2.3. Keep `split_cross_sprint_task()` as a thin deprecated wrapper
+  so `tracker.py` and `mcp_server.py` imports keep working through the phase.
+- Fix the `startDate`/`start_date` sort bug (§1.7) while rewriting
+  `sprint_summary_for_task` into `task_sprints_with_time`.
+- Ship `--dry-run` first and diff its plan against the Phase-0 GH snapshot for
+  all 14 multi-sprint tasks before allowing any writes.
+
+### Phase 3 — Update consumers
+
+- Delete every `cross_sprint_parent` filter and guard (§1.1) and
+  `wt list --shadows` (`wt.py:2503-2524`; it has no `_wt` completion entry).
+  Add `sync-sprints` to `_wt`, rename `split-sprint`.
+- Route all `github_issue` reads through `task_current_issue()`
+  (49 in `wt.py`, 53 in `tracker.py`, 46 in `mcp_server.py` — mostly mechanical).
+- Rework `close_task()`: call reconcile instead of the inline split; close
+  only the current binding.
+- Rework `wt sprint`, `wt report`, `wt done` output, `wt split-sprint` →
+  `wt sync-sprints`, `wt set-sprint` semantics, `TaskModal`'s sprint Select
+  (the `InvalidSelectValueError` workaround for out-of-window `sprint_id`
+  becomes unnecessary — it edits `start_sprint` now).
+- MCP: `sprint_split` → `sync_task_sprints`; `get_task` returns bindings.
+
+### Phase 4 — Retire the rituals
+
+- Rewrite `.claude/skills/close-sprint/SKILL.md`: steps 3 and 4 collapse into
+  one `wt sync-sprints --all` (still `--dry-run` + confirm first). Delete the
+  marker-log technique and step 0's misfiled-log repair.
+- Optionally delete the 3 existing 0-minute marker logs (harmless either way).
+- Update `CLAUDE.md`: the whole "Cross-sprint split workflow" / "shadow tasks"
+  sections.
+
+### Phase 5 — Collapse recurrent per-sprint copies (**separate decision**)
+
+Once 1–4 land, a recurrent task is just a task that never closes and grows one
+binding per sprint. That would let us retire `close-recurrent`, `new-recurrent`,
+`SPRINT_SUFFIX_RE`, `strip_sprint_suffix`, `_same_recurrent_series`, and revert
+calendar mappings from base-name to task-id keying (§1.6) — a big simplification
+that also structurally fixes the leaking-logs problem.
+
+But it's a large blast radius (two CLI commands, two MCP tools, two skills, the
+calendar mapping migration, and the TUI's second table), and it changes the
+shape of Carlos's per-sprint GitHub issues for recurring work. **Do not bundle
+it.** Decide after 1–4 are running clean for a sprint or two.
+
+---
+
+## 5. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **Multi-Mac / iCloud.** An old `wt.py` on the other Mac writes shadows or reads bindings it doesn't understand. | Update both Macs in the same session. Migration is idempotent and strips re-introduced shadows. Phase-0 backup before first migrating run. |
+| **Irreversible GH writes** during a buggy reconcile (issues created/closed). | `--dry-run` on every reconcile path, mandatory for `--all`. Compare against the Phase-0 snapshot. Under Option A a correct migration produces **zero** GH diff. |
+| **8 historical tasks have unsplit multi-sprint hours** (`Assist on Banco Galicia` 95+96, `casanabria - Brokkr support` 97+98, the `Ad-hoc Slack Questions`/`Time tracking` recurrent copies, …) — they predate the split feature. A blanket `sync-sprints --all` would mint ~10 new issues for closed sprints. | Migration **reports** them and creates bindings only for sprints that already have an issue. Backfilling old sprints is an explicit, separate, opt-in run. |
+| **Rounding.** `mins_to_quarter_hours` rounds *up* per sprint, so Σ(per-sprint hours) ≥ round(total). | Unchanged from today by design — the plan preserves the exact arithmetic. Flag it, don't "fix" it silently. |
+| **No test suite.** | Add `tools/check_invariants.py` (below) and run it before/after every phase. |
+| Bare issue numbers in bindings would break the cross-repo case. | §2.1: always store `owner/repo#n`. Assert it in the invariant checker. |
+
+## 6. Verification
+
+`tools/check_invariants.py`, runnable offline against the live file, asserting:
+
+1. No task has `cross_sprint_parent`; no task's title matches `… (Sprint N)`
+   shadow naming.
+2. Every `sprint_issues[].issue` matches `^[\w.-]+/[\w.-]+#\d+$`.
+3. Per task, `{binding.sprint_id}` ⊇ `{sprints with >0 logged minutes}`.
+4. No two bindings on a task share a `sprint_id`.
+5. Total log minutes and log count match the Phase-0 snapshot exactly.
+6. Every binding's `hours_synced == mins_to_quarter_hours(task_mins_for_sprint(...))`.
+7. (Online, optional) each binding's GH Project Hours/Sprint/Status matches the
+   Phase-0 snapshot.
+
+Manual smoke pass per phase: `wt list`, `wt sprint`, `wt report --sprint
+"Sprint 105"`, `wt logs <multi-sprint task>`, `wt sync-sprints --dry-run
+"IRON Infusion"`, TUI launch + `r` reload + board render + edit modal on a
+task with an old start sprint.
+
+---
+
+## 7. Open questions for Carlos
+
+1. **Option A vs B** (§2.4) — recommend A (zero GitHub-side change). Confirm.
+2. **Past-sprint issue titles.** Keep today's ` (Sprint N)` suffix on
+   past-sprint issues, or rely on the Project's Sprint field alone?
+3. **The 8 historical unsplit tasks** (§5) — leave as-is, or backfill issues for
+   their closed sprints?
+4. **Phase 5** — appetite for collapsing recurrent per-sprint copies later, or
+   keep per-sprint clones indefinitely?

--- a/docs/plan-sprint-bindings.md
+++ b/docs/plan-sprint-bindings.md
@@ -323,8 +323,14 @@ reconcile is no longer something the user has to be told to run.
   only the current binding.
 - Rework `wt sprint`, `wt report`, `wt done` output, `wt split-sprint` →
   `wt sync-sprints`, `wt set-sprint` semantics, `TaskModal`'s sprint Select
-  (the `InvalidSelectValueError` workaround for out-of-window `sprint_id`
-  becomes unnecessary — it edits `start_sprint` now).
+  (retargeted onto `start_sprint`).
+  - **Correction, found during implementation:** this section originally claimed
+    the `InvalidSelectValueError` workaround becomes unnecessary. It does not —
+    it becomes *more* necessary. `start_sprint_id` is frozen at the **earliest**
+    log, so it falls outside the Select's "current + previous 4" window far more
+    often than the old mutable `sprint_id` did (e.g. a task started in Sprint 95
+    with current = Sprint 105). Removing the workaround crashes the edit modal.
+    It was kept and retargeted.
 - MCP: `sprint_split` → `sync_task_sprints`; `get_task` returns bindings.
 
 ### Phase 4 — Retire the rituals
@@ -382,6 +388,41 @@ Manual smoke pass per phase: `wt list`, `wt sprint`, `wt report --sprint
 task with an old start sprint.
 
 ---
+
+## 6b. Known follow-ups (found while implementing phases 1–4, not fixed)
+
+Deliberately left out of scope so the phases stayed reviewable. None affects the
+"GitHub state is unchanged" property.
+
+1. **Three loaders, three migrations.** `wt.load()`, `mcp_server.load()` and
+   `tracker.load_data()` are independent; each needed
+   `_migrate_shadows_to_bindings` wired in separately. A shared loader would stop
+   the next migration from having to be remembered three times.
+2. **`get_sprint_date_range_for_task()` still keys on legacy `task["sprint_id"]`**,
+   so the TUI calendar modal's default date range for a carried-over task points
+   at the pre-rollover sprint. Should consult `current_binding()`.
+3. **`cmd_add` / `create_task_from_issue` set only `sprint`/`sprint_id`**, never
+   `start_sprint*`, so `wt sprint`'s "started Sprint N" is blank for
+   CLI-created tasks until their first reconcile. The TUI sets both.
+4. **Closing an open carry-over task can report 0h.** Reconcile targets the
+   current sprint for an open task, then `close_task` reports that binding — so
+   a task with no minutes yet in the current sprint closes its carried-forward
+   issue at 0.0h. This matches the old marker-log outcome, but reporting the
+   latest sprint *with time* may be the better rule. **Policy decision, not a
+   bug** — needs Carlos.
+5. **A stray 8-second timer log mints a whole past-sprint issue** billed at
+   0.25h, because `mins_to_quarter_hours` rounds up per sprint (preserved
+   deliberately, §5). A minimum-minutes threshold in `_reconcile_plan` would
+   avoid it.
+6. **`setup_issue_in_project()` sets the project Sprint field from the legacy
+   `task["sprint_id"]`** while taking Hours from the current binding. The
+   reconcile's `relabel` op keeps them agreeing today, but `wt set-sprint` no
+   longer touches `sprint_id`, so they could in principle diverge.
+7. **`close_task`'s "no issue" refusal is detected by string match** in
+   `mcp_server`; a structured `error_code` would be sturdier.
+8. **Legacy `sprint`/`sprint_id`/`github_issue` keys are still written** as a
+   mirror. Retiring them needs all three loaders updated at once plus both Macs
+   on the new code — a coordinated phase of its own.
 
 ## 7. Open questions for Carlos
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -25,13 +25,28 @@ from pathlib import Path
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
-from wt import sync_project_status, get_all_sprints, get_current_sprint, _match_sprint, split_cross_sprint_task, sprint_summary_for_task, delete_github_issue, setup_issue_in_project, mins_to_quarter_hours, task_logged_mins_for_sprint
+from wt import sync_project_status, get_all_sprints, get_current_sprint, _match_sprint, delete_github_issue, setup_issue_in_project, mins_to_quarter_hours
 from wt import build_time_report, format_time_report, _parse_last_arg, get_cached_sprints, get_role_ids
 from wt import find_recurrent_tasks_to_close, close_previous_sprint_recurrent_tasks
 from wt import get_task_repo, get_cached_project_options, _migrate_role_github_fields
+# Phase 3 (docs/plan-sprint-bindings.md §4): shadow tasks are gone, replaced by
+# per-sprint ``sprint_issues`` bindings. Every ``github_issue`` read goes through
+# ``task_current_issue`` and every write through ``set_task_current_issue`` /
+# ``clear_task_current_issue``; hours come from ``task_reportable_mins``; the
+# cross-sprint split is now ``reconcile_task_sprints``.
+from wt import _migrate_shadows_to_bindings
+from wt import (task_current_issue, set_task_current_issue, clear_task_current_issue,
+                current_binding, task_issue_refs, task_sprint_bindings,
+                task_start_sprint, task_reportable_mins, task_sprints_with_time,
+                reconcile_task_sprints, close_task)
+from wt import _reconcile_outcome_lines, _reconcile_plan_lines, _sprints_for_cli
+from wt import _resolve_data_file, fmt_mins as wt_fmt_mins
 from datetime import timedelta
 
-DATA_FILE = Path.home() / ".workload_tracker.json"
+# Same ``WT_DATA_FILE`` override wt.py uses (Phase 0), so a refactor can be
+# exercised against a throwaway copy instead of the live, iCloud-synced file.
+# Production runs never set it and this resolves to ~/.workload_tracker.json.
+DATA_FILE = _resolve_data_file()
 NOTES_DIR = Path.home() / ".workload_tracker_notes"
 
 DEFAULT_ROLES = [
@@ -67,7 +82,15 @@ def load() -> dict:
     if "roles" not in data:
         data["roles"] = DEFAULT_ROLES.copy()
     # Move role github fields onto tasks (idempotent, same as wt.load()).
-    if _migrate_role_github_fields(data):
+    mutated = _migrate_role_github_fields(data)
+    # Convert cross-sprint shadow tasks into per-sprint bindings, and strip
+    # re-introduced shadows on every load. This MUST run here: wt.load() already
+    # does it, so without it the MCP server would be the one process still seeing
+    # (and double-counting) shadow tasks that wt.py has converted — or, worse,
+    # would write a shadow-bearing file back over a migrated one. Note the
+    # deliberate non-short-circuit: both migrations always run.
+    mutated = _migrate_shadows_to_bindings(data) or mutated
+    if mutated:
         save(data)
     return data
 
@@ -205,8 +228,6 @@ def add_task(
         "logs": [],
         "created_at": time.time(),
     }
-    if github_issue:
-        task["github_issue"] = github_issue
     if github_repo:
         task["github_repo"] = github_repo
     if activity:
@@ -228,6 +249,11 @@ def add_task(
         if current:
             task["sprint"] = current["title"]
             task["sprint_id"] = current["id"]
+
+    # Record the link as a binding as well (after the sprint assignment, so the
+    # binding lands on the right sprint). Also rewrites the legacy github_issue key.
+    if github_issue:
+        set_task_current_issue(task, github_issue, data)
 
     data["tasks"].insert(0, task)
     save(data)
@@ -254,9 +280,9 @@ def list_tasks(role: str | None = None, status: str | None = None, include_done:
     at = data.get("active_timer")
     roles = get_roles(data)
 
-    # Always hide shadow tasks (cross-sprint splits)
-    tasks = [t for t in tasks if not t.get("cross_sprint_parent")]
-
+    # No shadow-task filter any more: cross-sprint work lives in the task's own
+    # ``sprint_issues`` bindings, so there is nothing hidden to exclude (plan
+    # §1.1). ``load()`` strips any shadow an older wt.py might reintroduce.
     if role:
         tasks = [t for t in tasks if t.get("role_id") == role]
     if status:
@@ -287,6 +313,11 @@ def list_tasks(role: str | None = None, status: str | None = None, include_done:
 def get_task(task_query: str) -> str:
     """Get details of a specific task by ID or title.
 
+    Includes the task's per-sprint GitHub issue bindings (``sprint_issues``) and
+    the sprint the work started in. A task worked across sprint boundaries has
+    one binding per sprint — its "current" issue is the newest one, and the
+    earlier ones are closed and carry that sprint's hours.
+
     Args:
         task_query: Task ID or partial title to search for
     """
@@ -300,20 +331,49 @@ def get_task(task_query: str) -> str:
     logged = task_logged_mins(task) + task_live_mins(task, at)
     running = at and at.get("task_id") == task["id"]
 
+    # Offline sprint list: get_task is a read-only lookup and must not depend on
+    # the network. Bindings carry their own sprint titles, so the cache is only
+    # needed to order them and to derive an unfrozen start sprint.
+    sprints = get_cached_sprints(data)
+    start = task_start_sprint(task, sprints)
+    start_label = task.get("start_sprint") or (start["title"] if start else None)
+
     lines = [
         f"Title: {task['title']}",
         f"ID: {task['id']}",
         f"Role: {roles.get(task['role_id'], task['role_id'])}",
         f"Sprint: {task.get('sprint') or '(none)'}",
+        f"Start sprint: {start_label or '(unknown)'}",
         f"Status: {STATUS_LABELS.get(task['status'], task['status'])}",
         f"Time logged: {fmt_mins(logged)}",
         f"Timer running: {'Yes' if running else 'No'}",
-        f"GitHub Issue: {task.get('github_issue') or '(none)'}",
+        f"GitHub Issue: {task_current_issue(task, data) or '(none)'}",
         f"GitHub Repo: {task.get('github_repo') or '(none)'}",
         f"Activity: {task.get('activity') or '(none)'}",
         f"Type: {task.get('type') or '(none)'}",
         f"Description: {task.get('description') or '(none)'}",
     ]
+
+    bindings = task_sprint_bindings(task, sprints)
+    if bindings:
+        current = current_binding(task, data)
+        lines.append(f"\nSprint issues ({len(bindings)}):")
+        for b in bindings:
+            marker = " ← current" if current is not None and b is current else ""
+            hours = b.get("hours_synced")
+            hours_str = f"{hours}h" if hours is not None else "hours not synced"
+            lines.append(
+                f"  {b.get('sprint') or b.get('sprint_id') or '(no sprint)':<12} "
+                f"{b.get('issue') or '(no issue)'}  [{b.get('state') or '?'}, "
+                f"{hours_str}]{marker}"
+            )
+
+    if sprints:
+        per_sprint = task_sprints_with_time(task, sprints)
+        if per_sprint:
+            lines.append("\nLogged time by sprint:")
+            for e in per_sprint:
+                lines.append(f"  {e['sprint_title']:<12} {fmt_mins(e['total_mins'])}")
 
     if task.get("logs"):
         lines.append("\nTime logs:")
@@ -893,63 +953,44 @@ def set_task_status(task_query: str, status: str, create_issue: bool = False) ->
 
     # Sync status to GitHub project if task has a linked issue
     result_msg = f"Changed '{task['title']}' from {STATUS_LABELS[old_status]} to {STATUS_LABELS[status]}"
-    if task.get("github_issue"):
-        if sync_project_status(task["github_issue"], status, data):
+    issue_ref = task_current_issue(task, data)
+    if issue_ref:
+        if sync_project_status(issue_ref, status, data):
             result_msg += f" (project synced)"
 
     return result_msg
 
 
 def _close_task_mcp(task: dict, data: dict, create_issue: bool) -> str:
-    """Handle task closing workflow for MCP."""
-    import subprocess
-    import re
+    """Close a task through the shared :func:`wt.close_task` workflow.
 
-    result_lines = []
+    Phase 3: this used to be a hand-rolled reimplementation that shelled out to
+    ``gh`` directly and reported ``round(total_minutes / 60)`` hours — the task's
+    *whole* total, which double-counts cross-sprint work whose earlier sprints are
+    already billed on their own issues. It now delegates to ``wt.close_task``, so
+    the MCP close does exactly what ``wt done`` and the TUI's ``D`` do:
 
-    # Check if the task has a GitHub repo
+      * reconciles the task's per-sprint bindings first, so each past sprint's
+        hours land on that sprint's own issue (plan §2.3/§2.4 Option A);
+      * reports the *current binding's* sprint hours via
+        ``task_reportable_mins``, rounded to quarter hours;
+      * sets Status/Activity/Type/Sprint on the project item and closes only the
+        current binding's issue.
+
+    ``create_issue`` is wired to ``close_task``'s ``prompt_callback``: False makes
+    the workflow refuse rather than mint an issue (``close_task`` with no callback
+    creates one unconditionally, which is *not* what create_issue=False means).
+    """
     repo = get_task_repo(task)
 
-    if not repo:
-        # No GitHub integration - just close
-        task["status"] = "done"
-        save(data)
-        return f"Closed '{task['title']}' (task has no repo — no GitHub integration)"
+    result = close_task(
+        task, data, save,
+        prompt_callback=lambda _msg: bool(create_issue),
+    )
 
-    # Check if task has GitHub issue
-    if not task.get("github_issue"):
-        if create_issue:
-            # Create the issue
-            try:
-                # Read local notes if they exist
-                npath = NOTES_DIR / f"{task['id']}.md"
-                body = ""
-                if npath.exists():
-                    body = npath.read_text()
-
-                cmd = ["gh", "issue", "create", "-R", repo, "--title", task["title"]]
-                if body:
-                    cmd.extend(["--body", body])
-                else:
-                    cmd.extend(["--body", f"Task created from workload tracker: {task['title']}"])
-
-                gh_result = subprocess.run(cmd, capture_output=True, text=True)
-                if gh_result.returncode != 0:
-                    return f"Error: Failed to create issue: {gh_result.stderr}"
-
-                # Parse issue URL
-                url = gh_result.stdout.strip()
-                url_match = re.match(r'https?://github\.com/([^/]+/[^/]+)/issues/(\d+)', url)
-                if url_match:
-                    issue_ref = f"{url_match.group(1)}#{url_match.group(2)}"
-                    task["github_issue"] = issue_ref
-                    save(data)
-                    result_lines.append(f"Created issue: {issue_ref}")
-                else:
-                    return f"Error: Could not parse issue URL: {url}"
-            except Exception as e:
-                return f"Error creating issue: {e}"
-        else:
+    if not result["success"]:
+        error = result.get("error") or "unknown error"
+        if not create_issue and "must have GitHub issue" in error:
             return (
                 f"Error: Task '{task['title']}' has no GitHub issue linked.\n"
                 f"This task has a repo configured ({repo}), so closing requires an issue.\n"
@@ -957,48 +998,37 @@ def _close_task_mcp(task: dict, data: dict, create_issue: bool) -> str:
                 f"  - Link an existing issue: link_github_issue('{task['title']}', 'owner/repo#123')\n"
                 f"  - Create one: set_task_status('{task['title']}', 'done', create_issue=True)"
             )
+        return f"Error closing '{task['title']}': {error}"
 
-    # Update project if configured
-    config = data.get("config", {})
-    if config.get("github_project_number"):
-        try:
-            owner = config.get("github_project_owner", "grafana")
-            project_num = config.get("github_project_number")
-            issue_url = f"https://github.com/{task['github_issue'].replace('#', '/issues/')}"
+    if result.get("skipped_github"):
+        return f"Closed '{task['title']}' (task has no repo — no GitHub integration)"
 
-            # Add to project
-            add_result = subprocess.run([
-                "gh", "project", "item-add", str(project_num),
-                "--owner", owner, "--url", issue_url, "--format", "json"
-            ], capture_output=True, text=True)
+    issue_ref = task_current_issue(task, data)
+    lines = [f"Closed '{task['title']}'"]
+    if result.get("issue_created"):
+        lines.append(f"  Created issue: {issue_ref}")
 
-            if add_result.returncode == 0:
-                total_mins = sum(l.get("minutes", 0) for l in task.get("logs", []))
-                hours = round(total_mins / 60)
-                result_lines.append(f"Added to project (Hours: {hours})")
-            else:
-                result_lines.append(f"Warning: Could not add to project: {add_result.stderr}")
-        except Exception as e:
-            result_lines.append(f"Warning: Project update failed: {e}")
+    # Per-sprint reconcile detail (issues minted/carried forward/closed for the
+    # sprints this task spanned). Rendered by wt so the wording matches `wt done`.
+    rec = result.get("reconcile_result")
+    if rec:
+        for line in _reconcile_outcome_lines(rec):
+            lines.append(f"  {line}")
 
-    # Close the GitHub issue
-    if task.get("github_issue"):
-        close_result = subprocess.run(
-            ["gh", "issue", "close", *gh_issue_args(task["github_issue"])],
-            capture_output=True, text=True
-        )
-        if close_result.returncode == 0:
-            result_lines.append(f"Closed issue: {task['github_issue']}")
-        else:
-            result_lines.append(f"Warning: Could not close issue: {close_result.stderr}")
+    if result.get("project_updated"):
+        binding = current_binding(task, data)
+        hours = binding.get("hours_synced") if binding else None
+        lines.append("  Added to project"
+                     + (f" (Hours: {hours})" if hours is not None else ""))
+    if result.get("issue_closed"):
+        lines.append(f"  Closed issue: {issue_ref}")
+    if result.get("comment_added"):
+        lines.append("  Added closing comment")
+    if result.get("error"):
+        # close_task marks the task done even when the project update fails.
+        lines.append(f"  Warning: {result['error']}")
 
-    # Mark as done
-    task["status"] = "done"
-    save(data)
-
-    result_lines.insert(0, f"Closed '{task['title']}'")
-
-    return "\n".join(result_lines)
+    return "\n".join(lines)
 
 
 @mcp.tool()
@@ -1031,7 +1061,8 @@ def close_previous_recurrent_tasks(all_previous: bool = False, dry_run: bool = F
     if dry_run:
         lines = [f"Would close {len(tasks)} recurrent task(s) from {scope}:"]
         for t in tasks:
-            lines.append(f"  - {t['title']} [{t.get('sprint', '?')}] {t.get('github_issue')}")
+            lines.append(f"  - {t['title']} [{t.get('sprint', '?')}] "
+                         f"{task_current_issue(t, data)}")
         return "\n".join(lines)
 
     summary = close_previous_sprint_recurrent_tasks(data, save, all_previous=all_previous)
@@ -1062,7 +1093,11 @@ def delete_task(task_query: str) -> str:
     if not task:
         return f"No task found matching '{task_query}'"
 
-    issue_ref = task.get("github_issue")
+    issue_ref = task_current_issue(task, data)
+    # Past-sprint bindings are separate, already-closed issues. Deleting them is
+    # not what delete_task ever did (they used to hang off shadow tasks), so name
+    # them instead of silently orphaning them.
+    other_issues = [r for r in task_issue_refs(task) if r != issue_ref]
     data["tasks"] = [t for t in data["tasks"] if t["id"] != task["id"]]
     if (data.get("active_timer") or {}).get("task_id") == task["id"]:
         data["active_timer"] = None
@@ -1074,6 +1109,9 @@ def delete_task(task_query: str) -> str:
             result += f"\nDeleted GitHub issue: {issue_ref}"
         else:
             result += f"\nWarning: Failed to delete GitHub issue {issue_ref} (may need admin permissions)"
+    if other_issues:
+        result += (f"\nNote: {len(other_issues)} past-sprint issue(s) left in place: "
+                   + ", ".join(other_issues))
     return result
 
 
@@ -1098,14 +1136,17 @@ def rename_task(task_query: str, new_title: str) -> str:
 
     result_lines = [f"Renamed '{old_title}' → '{new_title}'"]
 
-    # Update linked GitHub issue title if present
-    if task.get("github_issue"):
+    # Update the current binding's GitHub issue title if present. Past-sprint
+    # issues keep their " (Sprint N)" titles — renaming those is not this tool's
+    # job (and would need the suffix re-applied per binding).
+    issue_ref = task_current_issue(task, data)
+    if issue_ref:
         gh_result = subprocess.run(
-            ["gh", "issue", "edit", *gh_issue_args(task["github_issue"]), "--title", new_title],
+            ["gh", "issue", "edit", *gh_issue_args(issue_ref), "--title", new_title],
             capture_output=True, text=True
         )
         if gh_result.returncode == 0:
-            result_lines.append(f"Updated GitHub issue: {task['github_issue']}")
+            result_lines.append(f"Updated GitHub issue: {issue_ref}")
         else:
             result_lines.append(f"Warning: Failed to update GitHub issue title: {gh_result.stderr}")
 
@@ -1155,8 +1196,8 @@ def get_notes_path(task_query: str) -> str:
         return f"No task found matching '{task_query}'"
 
     # Check for GitHub issue first
-    if task.get("github_issue"):
-        gh_ref = task["github_issue"]
+    gh_ref = task_current_issue(task, data)
+    if gh_ref:
         return (
             f"Task '{task['title']}' is linked to GitHub issue: {gh_ref}\n"
             f"View: gh issue view {gh_ref}\n"
@@ -1180,6 +1221,10 @@ def push_task_to_github(task_query: str) -> str:
     Updates all GitHub Project fields that would be set during a close, but
     does NOT close the issue. The task remains in its current status.
 
+    Pushes to the task's *current* sprint binding's issue, with only that sprint's
+    hours — past sprints' hours already live on their own bindings' issues, so the
+    task total would double-count.
+
     Args:
         task_query: Task ID or partial title
     """
@@ -1187,13 +1232,13 @@ def push_task_to_github(task_query: str) -> str:
     task = resolve_task(data, task_query)
     if not task:
         return f"ERROR: no task matching '{task_query}'"
-    issue_ref = task.get("github_issue")
+    issue_ref = task_current_issue(task, data)
     if not issue_ref:
         return f"ERROR: task '{task['title']}' has no linked GitHub issue"
     result = setup_issue_in_project(issue_ref, task, data)
-    save(data)
+    save(data)  # persist the mark_logs_uploaded side-effect
     if result["success"]:
-        hours = mins_to_quarter_hours(task_logged_mins_for_sprint(task, get_all_sprints(data)))
+        hours = mins_to_quarter_hours(task_reportable_mins(task, get_all_sprints(data)))
         return f"Pushed '{task['title']}' to {issue_ref}: {hours}h"
     return f"Push completed with errors: {', '.join(result['errors'])}"
 
@@ -1229,7 +1274,9 @@ def link_github_issue(task_query: str, github_issue: str) -> str:
     import json as json_mod
     issue_info = json_mod.loads(result.stdout)
 
-    task["github_issue"] = github_issue
+    # Store the ref on the task's current sprint binding (and mirror the legacy
+    # github_issue key), rather than only writing the flat field.
+    set_task_current_issue(task, github_issue, data)
     # Pin the task's repo from the issue ref (so the close workflow engages)
     if not task.get("github_repo") and "#" in github_issue:
         task["github_repo"] = github_issue.split("#", 1)[0]
@@ -1250,13 +1297,17 @@ def unlink_github_issue(task_query: str) -> str:
     if not task:
         return f"No task found matching '{task_query}'"
 
-    if not task.get("github_issue"):
+    if not task_current_issue(task, data):
         return f"Task '{task['title']}' is not linked to a GitHub issue."
 
-    old_issue = task["github_issue"]
-    del task["github_issue"]
+    old_issue = clear_task_current_issue(task, data)
     save(data)
-    return f"Unlinked '{task['title']}' from {old_issue}"
+    msg = f"Unlinked '{task['title']}' from {old_issue}"
+    remaining = task_issue_refs(task)
+    if remaining:
+        msg += (f"\nStill bound to {len(remaining)} past-sprint issue(s): "
+                + ", ".join(remaining))
+    return msg
 
 
 @mcp.tool()
@@ -1273,11 +1324,12 @@ def view_github_issue(task_query: str) -> str:
     if not task:
         return f"No task found matching '{task_query}'"
 
-    if not task.get("github_issue"):
+    issue_ref = task_current_issue(task, data)
+    if not issue_ref:
         return f"Task '{task['title']}' is not linked to a GitHub issue."
 
     result = subprocess.run(
-        ["gh", "issue", "view", *gh_issue_args(task["github_issue"]), "--json", "title,body,comments"],
+        ["gh", "issue", "view", *gh_issue_args(issue_ref), "--json", "title,body,comments"],
         capture_output=True, text=True
     )
     if result.returncode != 0:
@@ -1315,17 +1367,18 @@ def add_github_comment(task_query: str, comment: str) -> str:
     if not task:
         return f"No task found matching '{task_query}'"
 
-    if not task.get("github_issue"):
+    issue_ref = task_current_issue(task, data)
+    if not issue_ref:
         return f"Task '{task['title']}' is not linked to a GitHub issue."
 
     result = subprocess.run(
-        ["gh", "issue", "comment", *gh_issue_args(task["github_issue"]), "-b", comment],
+        ["gh", "issue", "comment", *gh_issue_args(issue_ref), "-b", comment],
         capture_output=True, text=True
     )
     if result.returncode != 0:
         return f"Error adding comment: {result.stderr}"
 
-    return f"Added comment to {task['github_issue']}"
+    return f"Added comment to {issue_ref}"
 
 
 @mcp.tool()
@@ -1512,9 +1565,10 @@ def create_task_from_issue(issue_ref: str, role: str = "other") -> str:
     gh_state = issue_info.get("state", "OPEN").upper()
     status = "done" if gh_state == "CLOSED" else "inprogress"
 
-    # Check if task already exists for this issue
+    # Check if a task already exists for this issue — check every binding, not
+    # just the legacy field, so a past-sprint issue matches too.
     for t in data["tasks"]:
-        if t.get("github_issue") == issue_ref:
+        if issue_ref in task_issue_refs(t):
             return f"Task already exists for {issue_ref}: '{t['title']}' (id: {t['id']})"
 
     task = {
@@ -1525,11 +1579,12 @@ def create_task_from_issue(issue_ref: str, role: str = "other") -> str:
         "status": status,
         "logs": [],
         "created_at": time.time(),
-        "github_issue": issue_ref,
     }
     # The issue ref pins the task's repo
     if "#" in issue_ref:
         task["github_repo"] = issue_ref.split("#", 1)[0]
+    # Record the link as a binding (and mirror the legacy github_issue key).
+    set_task_current_issue(task, issue_ref, data)
     data["tasks"].insert(0, task)
     save(data)
 
@@ -1715,17 +1770,24 @@ def sync_arc_folders() -> str:
 def list_sprints() -> str:
     """List all available sprint iterations from the GitHub project."""
     data = load()
-    sprints = get_all_sprints(data)
+    # Prefer the live fetch, fall back to config.sprints_cache so this still
+    # answers offline. Read start_date/end_date (date objects), which both
+    # sources provide — the old code read the camelCase startDate/duration keys
+    # that only the live fetch emits, so a cache-backed dict raised KeyError.
+    sprints, from_cache = _sprints_for_cli(data)
     if not sprints:
         return "No sprints found (project not configured or query failed)."
 
-    current = get_current_sprint(data)
+    today = datetime.now().date()
+    current = next((s for s in sprints
+                    if s["start_date"] <= today < s["end_date"]), None)
     current_id = current["id"] if current else None
 
-    lines = ["Available sprints:"]
+    lines = ["Available sprints:" + ("  (offline — persisted cache)" if from_cache else "")]
     for s in sprints:
         marker = " ← current" if s["id"] == current_id else ""
-        lines.append(f"  {s['title']} ({s['startDate']}, {s['duration']} days){marker}")
+        days = (s["end_date"] - s["start_date"]).days
+        lines.append(f"  {s['title']} ({s['start_date']}, {days} days){marker}")
     return "\n".join(lines)
 
 
@@ -1733,23 +1795,42 @@ def list_sprints() -> str:
 def get_current_sprint_info() -> str:
     """Get information about the current sprint."""
     data = load()
-    current = get_current_sprint(data)
+    sprints, from_cache = _sprints_for_cli(data)
+    today = datetime.now().date()
+    current = next((s for s in sprints
+                    if s["start_date"] <= today < s["end_date"]), None)
     if not current:
         return "No active sprint found."
+    days = (current["end_date"] - current["start_date"]).days
+    last_day = current["end_date"] - timedelta(days=1)
     return (
         f"Current sprint: {current['title']}\n"
-        f"Start: {current['startDate']}\n"
-        f"Duration: {current['duration']} days"
+        f"Start: {current['start_date']}\n"
+        f"End: {last_day}\n"
+        f"Duration: {days} days"
+        + ("\n(offline — persisted sprints cache)" if from_cache else "")
     )
 
 
 @mcp.tool()
 def set_sprint(task_query: str, sprint_title: str) -> str:
-    """Set or change the sprint for a task.
+    """Correct the sprint a task *started* in.
+
+    Since the move to per-sprint issue bindings this no longer re-points a task
+    forward. Which sprint a task's hours are billed to is derived from its log
+    timestamps and materialised as ``sprint_issues`` bindings by
+    ``sync_task_sprints`` — it is not something to set by hand. The one sprint
+    field a human still owns is ``start_sprint`` ("when did this work begin"),
+    which is derived from the earliest log and then frozen so a later log edit
+    can't rewrite history. This tool is the override.
+
+    To change which sprint a task's *time* lands in, edit the log timestamps and
+    run ``sync_task_sprints(task_query)``.
 
     Args:
         task_query: Task ID or partial title
-        sprint_title: Sprint title (e.g., "Sprint 43") or "none" to clear
+        sprint_title: Sprint title (e.g., "Sprint 43"), or "none" to clear the
+            start sprint so it is re-derived from the task's earliest log.
     """
     data = load()
     task = resolve_task(data, task_query)
@@ -1757,12 +1838,15 @@ def set_sprint(task_query: str, sprint_title: str) -> str:
         return f"No task found matching '{task_query}'"
 
     if sprint_title.lower() == "none":
-        task.pop("sprint", None)
-        task.pop("sprint_id", None)
+        had = task.pop("start_sprint_id", None) is not None
+        had = (task.pop("start_sprint", None) is not None) or had
         save(data)
-        return f"Cleared sprint for '{task['title']}'"
+        if had:
+            return (f"Cleared the start sprint for '{task['title']}' — it will be "
+                    f"re-derived from the task's earliest log.")
+        return f"'{task['title']}' had no start sprint set."
 
-    all_sprints = get_all_sprints(data)
+    all_sprints, _ = _sprints_for_cli(data)
     if not all_sprints:
         return "No sprints found."
 
@@ -1771,48 +1855,152 @@ def set_sprint(task_query: str, sprint_title: str) -> str:
         available = ", ".join(s["title"] for s in all_sprints[-5:])
         return f"No sprint matching '{sprint_title}'. Recent: {available}"
 
-    task["sprint"] = match["title"]
-    task["sprint_id"] = match["id"]
+    task["start_sprint"] = match["title"]
+    task["start_sprint_id"] = match["id"]
     save(data)
-    return f"Set sprint for '{task['title']}' to {match['title']}"
+    return (f"'{task['title']}' now starts in {match['title']} (start sprint only — "
+            f"hours follow the logs; run sync_task_sprints to re-derive bindings)")
 
 
 @mcp.tool()
-def sprint_split(task_query: str) -> str:
-    """Split a cross-sprint task: create shadow tasks for previous sprints.
+def sync_task_sprints(
+    task_query: str | None = None,
+    all_tasks: bool = False,
+    create_issues: bool | None = None,
+    dry_run: bool = False,
+) -> str:
+    """Reconcile a task's per-sprint GitHub issue bindings against its logs.
 
-    If a task has time logged in multiple sprints, this creates separate GitHub
-    issues for each previous sprint with the correct hours, and updates the main
-    task to only show the most recent sprint's hours.
+    Replaces the old ``sprint_split`` tool. For each sprint the task has logged
+    time in (plus the current sprint while the task is open) there should be one
+    ``sprint_issues`` binding carrying that sprint's hours. This creates the
+    missing ones, carries the task's current issue forward to its most recent
+    sprint, re-pushes hours that have drifted, and closes issues whose sprint has
+    ended. Idempotent: a second run finds nothing to do.
+
+    Recurrent tasks are **skipped** and reported — they intentionally span
+    sprints and are handled by close_previous_recurrent_tasks / ``wt
+    new-recurrent`` instead.
 
     Args:
-        task_query: Task ID or partial title
+        task_query: Task ID or partial title. Required unless all_tasks=True.
+        all_tasks: Reconcile every non-recurrent task instead of one.
+        create_issues: Whether new GitHub issues may be minted for sprints that
+            have none. Defaults to True for a single task and **False** for
+            all_tasks=True, because a blanket run over the real data would mint
+            ~25 issues; pass True explicitly to allow that. Sprints that would
+            need an issue are reported rather than bound issue-less, so a later
+            create_issues=True run can still mint them.
+        dry_run: Print the plan and change nothing (no GitHub calls at all).
     """
+    if all_tasks and task_query:
+        return "Error: pass either task_query or all_tasks=True, not both."
+    if not all_tasks and not task_query:
+        return "Error: task_query is required unless all_tasks=True."
+
     data = load()
-    task = resolve_task(data, task_query)
-    if not task:
-        return f"No task found matching '{task_query}'"
-
-    all_sprints = get_all_sprints(data)
+    all_sprints, from_cache = _sprints_for_cli(data)
     if not all_sprints:
-        return "No sprints found."
+        return "No sprints found (project not configured or query failed)."
 
-    summary = sprint_summary_for_task(task, all_sprints)
-    if len(summary) <= 1:
-        sprint_name = summary[0]["sprint_title"] if summary else task.get("sprint", "unknown")
-        return f"Task '{task['title']}' only has time in {sprint_name}. No split needed."
+    # Requirement (a): a blanket run must not mint issues by default.
+    if create_issues is None:
+        create_issues = not all_tasks
 
-    from wt import fmt_mins as wt_fmt
-    result = split_cross_sprint_task(task, data, save, all_sprints)
-    if result.get("success"):
-        lines = [f"Split '{task['title']}' across {len(summary)} sprints:"]
-        for st in result.get("sprint_tasks_created", []):
-            issue = st.get("issue_ref", "no issue")
-            lines.append(f"  {st['sprint']}: {wt_fmt(st['total_mins'])} → {issue}")
-        lines.append(f"  Main task: {result.get('main_sprint', '?')}")
-        return "\n".join(lines)
+    if all_tasks:
+        candidates = list(data.get("tasks", []))
     else:
-        return f"Split failed: {result.get('error', 'unknown')}"
+        task = resolve_task(data, task_query)
+        if not task:
+            return f"No task found matching '{task_query}'"
+        candidates = [task]
+
+    # Requirement (b): skip recurrent tasks and say so.
+    targets, skipped_tasks = [], []
+    for t in candidates:
+        if t.get("status") == "recurrent":
+            skipped_tasks.append(t)
+            continue
+        targets.append(t)
+
+    header = []
+    if from_cache:
+        header.append("(offline — using the persisted sprints cache)")
+    if skipped_tasks:
+        header.append(f"Skipped {len(skipped_tasks)} recurrent task(s) "
+                      f"(use close_previous_recurrent_tasks / wt new-recurrent):")
+        for t in skipped_tasks:
+            header.append(f"  - {t['title']} [{t.get('sprint', '?')}]")
+
+    # Plan pass. dry_run=True is structurally read-only in reconcile_task_sprints
+    # (it plans, then returns without executing), so this makes no GitHub calls.
+    plans = []
+    for t in targets:
+        res = reconcile_task_sprints(t, data, all_sprints,
+                                     create_issues=create_issues, dry_run=True)
+        if res.get("error") or res.get("planned") or any(
+            sk.get("needs_issue") for sk in res.get("skipped", [])
+        ):
+            plans.append((t, res))
+
+    if not plans:
+        return "\n".join(header + [
+            f"Nothing to do ({len(targets)} task(s) already in sync)."])
+
+    lines = list(header)
+    n_create = n_repoint = n_hours = n_close = n_needs_issue = 0
+    lines.append(f"{'Plan' if dry_run else 'Reconciling'} for {len(plans)} task(s):")
+    for t, res in plans:
+        lines.append(f"\n  {t['title']}")
+        if res.get("error"):
+            lines.append(f"    ! {res['error']}")
+            continue
+        breakdown = ", ".join(f"{e['sprint']}={wt_fmt_mins(e['minutes'])}"
+                              for e in res.get("target", []))
+        if breakdown:
+            lines.append(f"    logs by sprint: {breakdown}")
+        for line in _reconcile_plan_lines(res):
+            lines.append(f"    {line}")
+        for op in res.get("planned", []):
+            if op["op"] == "create":
+                n_create += 1 if op.get("create_issue") else 0
+            elif op["op"] == "repoint":
+                n_repoint += 1
+            elif op["op"] == "hours":
+                n_hours += 1
+            elif op["op"] == "close":
+                n_close += 1
+        n_needs_issue += sum(1 for sk in res.get("skipped", []) if sk.get("needs_issue"))
+
+    lines.append(f"\nTotals: {n_create} issue(s) to create, {n_repoint} to re-point, "
+                 f"{n_hours} hours update(s), {n_close} issue(s) to close.")
+    if n_needs_issue:
+        lines.append(f"{n_needs_issue} past sprint(s) with unbilled time were NOT bound "
+                     f"(create_issues is False).")
+    if all_tasks and not create_issues:
+        lines.append("all_tasks does not create GitHub issues; "
+                     "pass create_issues=True to allow it.")
+
+    if dry_run:
+        lines.append("\nDry run — nothing was changed.")
+        return "\n".join(lines)
+
+    lines.append("\nResults:")
+    failures = 0
+    for t, _plan in plans:
+        lines.append(f"\n  {t['title']}")
+        res = reconcile_task_sprints(t, data, all_sprints, create_issues=create_issues,
+                                     save_callback=save)
+        outcome = _reconcile_outcome_lines(res)
+        for line in outcome:
+            lines.append(f"    {line}")
+        if not outcome:
+            lines.append("    (nothing to do)")
+        if not res.get("success"):
+            failures += 1
+    save(data)
+    lines.append(f"\n{'Done.' if not failures else f'{failures} task(s) had errors.'}")
+    return "\n".join(lines)
 
 
 if __name__ == "__main__":

--- a/tools/baseline.py
+++ b/tools/baseline.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Capture a pre-migration baseline of local time-tracking invariants.
+
+Phase 0 of docs/plan-sprint-bindings.md. Reads a data file WITHOUT going
+through wt.load() (so no migration runs) and writes a JSON snapshot that
+tools/check_invariants.py asserts against afterwards.
+
+    python3 tools/baseline.py <data.json> <baseline-out.json>
+
+The snapshot is keyed by task id and deliberately records only things the
+migration must NOT change: log minutes and log counts. Shadow tasks are
+recorded separately with their parent, so the checker can verify each shadow
+became a binding on the right task.
+"""
+import json
+import sys
+from pathlib import Path
+
+
+def capture(data: dict) -> dict:
+    tasks = data.get("tasks", [])
+    per_task = {}
+    shadows = {}
+    for t in tasks:
+        logs = t.get("logs", [])
+        per_task[t["id"]] = {
+            "title": t.get("title", ""),
+            "minutes": round(sum(l.get("minutes", 0) for l in logs), 6),
+            "log_count": len(logs),
+            "log_ids": sorted(l.get("id", "") for l in logs),
+            "github_issue": t.get("github_issue"),
+            "sprint_id": t.get("sprint_id"),
+            "sprint": t.get("sprint"),
+            "status": t.get("status"),
+        }
+        if t.get("cross_sprint_parent"):
+            shadows[t["id"]] = {
+                "title": t.get("title", ""),
+                "parent": t["cross_sprint_parent"],
+                "sprint_id": t.get("sprint_id"),
+                "sprint": t.get("sprint"),
+                "github_issue": t.get("github_issue"),
+                "marker_minutes": round(sum(l.get("minutes", 0) for l in t.get("logs", [])), 6),
+            }
+
+    non_shadow = [t for t in tasks if not t.get("cross_sprint_parent")]
+    return {
+        "task_count": len(tasks),
+        "shadow_count": len(shadows),
+        "non_shadow_count": len(non_shadow),
+        # The number that must never move: total tracked time excluding shadows,
+        # since shadow marker logs duplicate their parent's real logs.
+        "total_minutes_excluding_shadows": round(
+            sum(sum(l.get("minutes", 0) for l in t.get("logs", [])) for t in non_shadow), 6
+        ),
+        "total_log_count_excluding_shadows": sum(len(t.get("logs", [])) for t in non_shadow),
+        "tasks": per_task,
+        "shadows": shadows,
+    }
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(__doc__.strip(), file=sys.stderr)
+        return 2
+    src, dest = Path(sys.argv[1]).expanduser(), Path(sys.argv[2]).expanduser()
+    snap = capture(json.loads(src.read_text()))
+    dest.write_text(json.dumps(snap, indent=2, sort_keys=True))
+    print(f"baseline -> {dest}")
+    print(f"  tasks={snap['task_count']} (shadows={snap['shadow_count']}, "
+          f"non-shadow={snap['non_shadow_count']})")
+    print(f"  minutes excluding shadows={snap['total_minutes_excluding_shadows']}")
+    print(f"  logs excluding shadows={snap['total_log_count_excluding_shadows']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_invariants.py
+++ b/tools/check_invariants.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Assert the sprint-bindings invariants from docs/plan-sprint-bindings.md §6.
+
+Runs fully offline (no `gh`, no network) and reads the data file **directly**,
+without going through ``wt.load()``, so it reports what is actually on disk
+rather than what a migration would produce.
+
+    python3 tools/check_invariants.py <data.json> [baseline.json]
+
+Exit status: 0 when every invariant holds, 1 when any FAIL is reported.
+Warnings never fail the run — they flag known-historical data (see plan §5).
+
+Invariants:
+  1. No task carries ``cross_sprint_parent``. Titles that look like shadow
+     naming (``… (Sprint N)``) are warned about, not failed: a real task could
+     legitimately be titled that way.
+  2. Every ``sprint_issues[].issue`` is a full ``owner/repo#n`` ref. Bare
+     numbers would corrupt the cross-repo cases in the live data.
+  3. Per task, {binding sprint_ids} ⊇ {sprints with >0 logged minutes}.
+     WARNING only — 8 tasks predate the split feature (plan §5); Phase 2's
+     reconcile closes the gap.
+  4. No two bindings on a task share a ``sprint_id``.
+  5. Against the baseline: task/log/minute totals for surviving tasks are
+     byte-identical (all relative to the baseline — never hardcoded).
+  6. Every shadow recorded in the baseline now exists as a binding, with the
+     right issue and hours, on the right parent task.
+"""
+import json
+import math
+import re
+import sys
+from pathlib import Path
+
+ISSUE_RE = re.compile(r"^[\w.-]+/[\w.-]+#\d+$")
+SHADOW_TITLE_RE = re.compile(r"\(Sprint\s+\d+\)\s*$", re.IGNORECASE)
+
+
+class Report:
+    def __init__(self) -> None:
+        self.failures: list[str] = []
+        self.warnings: list[str] = []
+
+    def fail(self, invariant: str, msg: str) -> None:
+        self.failures.append(f"[{invariant}] {msg}")
+
+    def warn(self, invariant: str, msg: str) -> None:
+        self.warnings.append(f"[{invariant}] {msg}")
+
+    def check(self, ok: bool, invariant: str, msg: str) -> bool:
+        if not ok:
+            self.fail(invariant, msg)
+        return ok
+
+
+def _mins(task: dict) -> float:
+    return sum(l.get("minutes", 0) for l in task.get("logs", []))
+
+
+def _log_effective_date(log: dict) -> float:
+    """Mirror of wt.log_effective_date (kept local so this tool stays standalone)."""
+    return log.get("started_at") or log.get("at", 0)
+
+
+def _round_up_quarter_hours(mins: float) -> float:
+    """Mirror of wt.mins_to_quarter_hours."""
+    return (math.ceil(mins / 15) * 15) / 60
+
+
+def _cached_sprints(data: dict) -> list[dict]:
+    from datetime import date
+    out = []
+    for s in data.get("config", {}).get("sprints_cache", []):
+        try:
+            out.append({
+                "id": s["id"],
+                "title": s["title"],
+                "start_date": date.fromisoformat(s["start_date"]),
+                "end_date": date.fromisoformat(s["end_date"]),
+            })
+        except (KeyError, ValueError):
+            continue
+    return out
+
+
+def _sprints_with_time(task: dict, sprints: list[dict]) -> dict:
+    """sprint_id -> minutes, for sprints where the task logged > 0 minutes."""
+    from datetime import datetime
+    totals: dict[str, float] = {}
+    for log in task.get("logs", []):
+        ts = _log_effective_date(log)
+        if not ts:
+            continue
+        day = datetime.fromtimestamp(ts).date()
+        for s in sprints:
+            if s["start_date"] <= day < s["end_date"]:
+                totals[s["id"]] = totals.get(s["id"], 0) + log.get("minutes", 0)
+                break
+    return {sid: m for sid, m in totals.items() if m > 0}
+
+
+def check_data(data: dict, rep: Report) -> None:
+    tasks = data.get("tasks", [])
+    sprints = _cached_sprints(data)
+    sprint_titles = {s["id"]: s["title"] for s in sprints}
+
+    # 1. No shadows.
+    shadows = [t for t in tasks if t.get("cross_sprint_parent")]
+    rep.check(not shadows, "1/no-shadows",
+              f"{len(shadows)} task(s) still carry cross_sprint_parent: "
+              + ", ".join(f"{t.get('title')!r} ({t.get('id')})" for t in shadows))
+    for t in tasks:
+        if SHADOW_TITLE_RE.search(t.get("title", "")):
+            rep.warn("1/shadow-naming",
+                     f"task {t.get('title')!r} ({t.get('id')}) looks like shadow "
+                     "naming — verify it is a real task")
+
+    for t in tasks:
+        bindings = t.get("sprint_issues")
+        if bindings is None:
+            rep.warn("2/no-bindings-key",
+                     f"task {t.get('title')!r} ({t.get('id')}) has no sprint_issues key "
+                     "(un-migrated?)")
+            continue
+        if not isinstance(bindings, list):
+            rep.fail("2/bindings-shape",
+                     f"task {t.get('title')!r} ({t.get('id')}) sprint_issues is "
+                     f"{type(bindings).__name__}, expected list")
+            continue
+
+        # 2. Full owner/repo#n issue refs.
+        for b in bindings:
+            issue = b.get("issue")
+            if issue is None:
+                continue
+            rep.check(bool(ISSUE_RE.match(str(issue))), "2/issue-ref",
+                      f"task {t.get('title')!r} ({t.get('id')}) binding for "
+                      f"{b.get('sprint') or b.get('sprint_id')} has malformed issue "
+                      f"{issue!r} — must be owner/repo#n")
+
+        # 4. One binding per sprint.
+        seen: dict = {}
+        for b in bindings:
+            sid = b.get("sprint_id")
+            if sid in seen:
+                rep.fail("4/duplicate-binding",
+                         f"task {t.get('title')!r} ({t.get('id')}) has two bindings for "
+                         f"sprint_id {sid!r}")
+            seen[sid] = b
+
+        # 3. Bindings cover every sprint with logged time (warning; plan §5).
+        if sprints:
+            with_time = _sprints_with_time(t, sprints)
+            missing = sorted(set(with_time) - set(seen),
+                             key=lambda sid: sprint_titles.get(sid, sid))
+            if missing:
+                detail = ", ".join(
+                    f"{sprint_titles.get(sid, sid)}={with_time[sid]:.0f}m" for sid in missing
+                )
+                rep.warn("3/binding-coverage",
+                         f"task {t.get('title')!r} ({t.get('id')}) has logged time in "
+                         f"unbound sprint(s): {detail}")
+
+
+def check_against_baseline(data: dict, base: dict, rep: Report) -> None:
+    tasks = data.get("tasks", [])
+    by_id = {t["id"]: t for t in tasks if t.get("id")}
+    base_tasks = base.get("tasks", {})
+    base_shadows = base.get("shadows", {})
+
+    # 5. Totals, relative to the baseline (never hardcoded).
+    rep.check(len(tasks) == base["non_shadow_count"], "5/task-count",
+              f"task count is {len(tasks)}, baseline non-shadow count is "
+              f"{base['non_shadow_count']}")
+
+    total_mins = round(sum(_mins(t) for t in tasks), 6)
+    rep.check(total_mins == base["total_minutes_excluding_shadows"], "5/total-minutes",
+              f"total minutes {total_mins} != baseline "
+              f"{base['total_minutes_excluding_shadows']}")
+
+    total_logs = sum(len(t.get("logs", [])) for t in tasks)
+    rep.check(total_logs == base["total_log_count_excluding_shadows"], "5/total-logs",
+              f"total log count {total_logs} != baseline "
+              f"{base['total_log_count_excluding_shadows']}")
+
+    # Every non-shadow baseline task must survive with identical logs.
+    for tid, snap in base_tasks.items():
+        if tid in base_shadows:
+            rep.check(tid not in by_id, "5/shadow-removed",
+                      f"shadow task {snap['title']!r} ({tid}) still present")
+            continue
+        task = by_id.get(tid)
+        if task is None:
+            rep.fail("5/task-missing", f"task {snap['title']!r} ({tid}) disappeared")
+            continue
+        rep.check(round(_mins(task), 6) == snap["minutes"], "5/task-minutes",
+                  f"task {snap['title']!r} ({tid}) minutes {round(_mins(task), 6)} != "
+                  f"baseline {snap['minutes']}")
+        rep.check(len(task.get("logs", [])) == snap["log_count"], "5/task-log-count",
+                  f"task {snap['title']!r} ({tid}) log count "
+                  f"{len(task.get('logs', []))} != baseline {snap['log_count']}")
+        log_ids = sorted(l.get("id", "") for l in task.get("logs", []))
+        rep.check(log_ids == snap["log_ids"], "5/task-log-ids",
+                  f"task {snap['title']!r} ({tid}) log ids changed")
+
+    # Unexpected new tasks (the migration must not invent any).
+    for tid, task in by_id.items():
+        if tid not in base_tasks:
+            rep.fail("5/task-added",
+                     f"task {task.get('title')!r} ({tid}) is not in the baseline")
+
+    # 6. Each baseline shadow now lives as a binding on its parent.
+    for sid, snap in base_shadows.items():
+        parent = by_id.get(snap["parent"])
+        if parent is None:
+            rep.warn("6/shadow-parent-missing",
+                     f"shadow {snap['title']!r} ({sid}) parent {snap['parent']} not in "
+                     "data — orphan shadows are kept, not converted")
+            continue
+        bindings = parent.get("sprint_issues") or []
+        match = next((b for b in bindings if b.get("sprint_id") == snap["sprint_id"]), None)
+        if match is None:
+            rep.fail("6/shadow-binding-missing",
+                     f"parent {parent.get('title')!r} has no binding for "
+                     f"{snap['sprint']} (from shadow {snap['title']!r})")
+            continue
+        rep.check(match.get("issue") == snap["github_issue"], "6/shadow-binding-issue",
+                  f"parent {parent.get('title')!r} binding for {snap['sprint']} has issue "
+                  f"{match.get('issue')!r}, shadow had {snap['github_issue']!r}")
+        expected_hours = _round_up_quarter_hours(snap["marker_minutes"])
+        rep.check(match.get("hours_synced") == expected_hours, "6/shadow-binding-hours",
+                  f"parent {parent.get('title')!r} binding for {snap['sprint']} has "
+                  f"hours_synced {match.get('hours_synced')!r}, expected "
+                  f"{expected_hours} (from {snap['marker_minutes']}m)")
+        rep.check(match.get("state") == "closed", "6/shadow-binding-state",
+                  f"parent {parent.get('title')!r} binding for {snap['sprint']} state is "
+                  f"{match.get('state')!r}, expected 'closed'")
+
+
+def main() -> int:
+    if len(sys.argv) not in (2, 3):
+        print(__doc__.strip(), file=sys.stderr)
+        return 2
+    data_path = Path(sys.argv[1]).expanduser()
+    data = json.loads(data_path.read_text())
+
+    rep = Report()
+    check_data(data, rep)
+
+    if len(sys.argv) == 3:
+        base = json.loads(Path(sys.argv[2]).expanduser().read_text())
+        check_against_baseline(data, base, rep)
+    else:
+        rep.warn("5/no-baseline", "no baseline given — skipped totals comparison")
+
+    tasks = data.get("tasks", [])
+    bindings = sum(len(t.get("sprint_issues") or []) for t in tasks)
+    print(f"checked {data_path}")
+    print(f"  tasks={len(tasks)}  bindings={bindings}  "
+          f"minutes={round(sum(_mins(t) for t in tasks), 2)}  "
+          f"logs={sum(len(t.get('logs', [])) for t in tasks)}")
+
+    if rep.warnings:
+        print(f"\n{len(rep.warnings)} warning(s):")
+        for w in rep.warnings:
+            print(f"  ! {w}")
+    if rep.failures:
+        print(f"\n{len(rep.failures)} FAILURE(s):")
+        for f in rep.failures:
+            print(f"  x {f}")
+        return 1
+    print("\nAll invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/compare_close_task.py
+++ b/tools/compare_close_task.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Diff the GitHub-visible effect of ``close_task()`` before vs after Phase 3.
+
+Option A of docs/plan-sprint-bindings.md §2.4 says the restructuring must be
+**local only**: GitHub state should not change. This script proves it for the
+close path by running ``close_task()`` on the same task under both versions of
+``wt.py`` — every ``gh``-touching function stubbed — and diffing the resulting
+sequence of GitHub operations.
+
+    venv/bin/python tools/compare_close_task.py <old_wt.py> <migrated.json> <scratch>
+
+Minted issue numbers are normalised (``NEW#1``, ``NEW#2``, …) because the stub
+allocates them in call order; everything else must match exactly.
+
+Exit status 0 when every task's op sequence is identical.
+"""
+import copy
+import importlib.util
+import json
+import os
+import re
+import shutil
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "tools"))
+
+from test_reconcile import Stubs  # noqa: E402
+
+# Tasks exercised: the multi-sprint ones (where the split/reconcile matters) plus
+# a couple of single-sprint controls.
+TASKS = [
+    "Assist on Banco Galicia",
+    "casanabria - Brokkr support for GrafanaCon",
+    "IRON Infusion",
+    "Build AMER Partner Demo Kit",
+    "Move demo block scripts to the new field-eng-demo-blocks repo",
+    "CI Check to read Demo Blocks content and verify if the change would break "
+    "the demo block",
+    "Document current FE platform",
+    "CAP audit cleanup: revoke unused tokens and orphaned policies",
+    "Time tracking - Sprint 103",
+    "Ad-hoc Slack Questions - Sprint 102",
+    "Update SLO Workshop",              # single sprint control
+    "Compliance Week",                  # current-sprint control
+]
+
+# Ops that change GitHub. Everything else (get_project_info, add_issue_to_project,
+# get_project_hours, issue_has_comments) is a read and is ignored.
+WRITE_OPS = {
+    "create_github_issue", "close_github_issue", "sync_project_status",
+    "update_project_hours", "update_project_sprint", "update_project_activity",
+    "update_project_type", "add_issue_comment", "add_to_project_and_update",
+    "update_issue_title", "delete_github_issue",
+}
+
+
+def load_module(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def normalise(calls, issue_map):
+    """Turn recorded stub calls into comparable strings."""
+    out = []
+    for name, args, kwargs in calls:
+        if name not in WRITE_OPS:
+            continue
+        if name == "create_github_issue":
+            task, repo = args[0], args[1]
+            out.append(f"create_github_issue({task.get('title')!r}, {repo!r})")
+            continue
+        parts = []
+        for a in args[1:] if False else args:
+            if isinstance(a, str):
+                parts.append(repr(issue_map.get(a, a)))
+            elif isinstance(a, dict):
+                parts.append("<dict>")
+            else:
+                parts.append(repr(a))
+        out.append(f"{name}({', '.join(parts)})")
+    return out
+
+
+class Recorder(Stubs):
+    """Stubs + a stable issue-number allocator shared across both versions."""
+
+    def __init__(self, wt, sprints):
+        super().__init__(wt, mode="record", sprints=sprints)
+        self.minted = []
+
+    def _make(self, name):
+        inner = super()._make(name)
+
+        def stub(*args, **kwargs):
+            ref = inner(*args, **kwargs)
+            if name == "create_github_issue":
+                self.minted.append(ref)
+            return ref
+        return stub
+
+    def __enter__(self):
+        super().__enter__()
+        self.wt.get_all_sprints = lambda d, _s=self.sprints: copy.deepcopy(_s)
+        return self
+
+
+def run_one(wt, migrated, work, title):
+    work = Path(work)
+    shutil.copyfile(migrated, work)
+    os.environ["WT_DATA_FILE"] = str(work)
+    wt.DATA_FILE = work
+    assert work != Path.home() / ".workload_tracker.json"
+    data = wt.load()
+    sprints = wt.get_cached_sprints(data)
+    task = next((t for t in data["tasks"] if t["title"] == title), None)
+    if task is None:
+        return None, None, f"task not found: {title!r}"
+    with Recorder(wt, sprints) as rec:
+        try:
+            res = wt.close_task(task, data, wt.save)
+            err = None
+        except Exception as e:                      # pragma: no cover
+            res, err = None, f"{type(e).__name__}: {e}"
+        issue_map = {ref: f"NEW#{i + 1}" for i, ref in enumerate(rec.minted)}
+        ops = normalise(rec.calls, issue_map)
+    summary = None if res is None else {
+        k: res[k] for k in ("success", "issue_created", "issue_closed",
+                            "project_updated", "skipped_github", "error")
+    }
+    return ops, summary, err
+
+
+def main():
+    if len(sys.argv) != 4:
+        print(__doc__.strip(), file=sys.stderr)
+        return 2
+    old_path, migrated, scratch = (Path(a).expanduser() for a in sys.argv[1:])
+    scratch.mkdir(parents=True, exist_ok=True)
+    os.environ.setdefault("WT_DATA_FILE", str(scratch / "unused.json"))
+
+    new_wt = load_module(REPO / "wt.py", "wt_new")
+    old_wt = load_module(old_path, "wt_old")
+    real = Path.home() / ".workload_tracker.json"
+    for m in (new_wt, old_wt):
+        if m.DATA_FILE == real:
+            print("REFUSING TO RUN: DATA_FILE is the live file", file=sys.stderr)
+            return 2
+
+    diffs = 0
+    for title in TASKS:
+        old_ops, old_sum, old_err = run_one(old_wt, migrated, scratch / "old.json", title)
+        new_ops, new_sum, new_err = run_one(new_wt, migrated, scratch / "new.json", title)
+        label = title[:58]
+        if old_err or new_err:
+            print(f"  ERR  {label}\n       old: {old_err}\n       new: {new_err}")
+            diffs += 1
+            continue
+        if old_ops == new_ops:
+            print(f"  same {label}  ({len(old_ops)} GitHub write op(s))")
+            continue
+        diffs += 1
+        print(f"  DIFF {label}")
+        print(f"       old summary: {old_sum}")
+        print(f"       new summary: {new_sum}")
+        import difflib
+        for line in difflib.unified_diff(old_ops, new_ops, "old", "new", lineterm="", n=1):
+            print(f"       {line}")
+
+    print(f"\n{len(TASKS) - diffs}/{len(TASKS)} tasks produce an identical GitHub "
+          f"write sequence")
+    return 1 if diffs else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_mcp_phase3.py
+++ b/tools/test_mcp_phase3.py
@@ -1,0 +1,904 @@
+#!/usr/bin/env python3
+"""Verification harness for Phase 3 of docs/plan-sprint-bindings.md — mcp_server.py.
+
+There is no automated test suite in this repo, so this script *is* the test for
+the MCP half of Phase 3. It runs fully offline:
+
+  * every ``gh``-touching function in ``wt`` is monkeypatched (Phase 2's ``Stubs``
+    from ``tools/test_reconcile.py`` is reused verbatim), and ``wt.subprocess``
+    is swapped for a guard that raises on any attribute access;
+  * ``mcp_server`` re-binds several of those names at import time
+    (``get_all_sprints``, ``get_current_sprint``, ``delete_github_issue``,
+    ``sync_project_status``), so those module attributes are patched too;
+  * several MCP tools shell out via a *function-local* ``import subprocess``,
+    which resolves through ``sys.modules`` at call time and therefore cannot be
+    intercepted by a module attribute. ``sys.modules["subprocess"]`` is swapped
+    for a recording fake for the duration of those calls, so an unstubbed
+    ``gh`` invocation raises instead of reaching real GitHub;
+  * every run happens on a fresh copy in a scratch dir, and the script refuses
+    to start if ``WT_DATA_FILE`` resolves to the live data file.
+
+Usage:
+
+    WT_DATA_FILE=<scratch>/unused.json \\
+    venv/bin/python test_mcp_phase3.py <fixture.json> <migrated.json> \\
+                                       <baseline.pristine.json> <scratch-dir>
+
+Exit status 0 when every check passes.
+"""
+import asyncio
+import copy
+import inspect
+import json
+import os
+import shutil
+import subprocess as real_subprocess
+import sys
+from pathlib import Path
+
+REPO = Path("/Users/carlos/dev/carlos/workload-tracker/.claude/worktrees/sprint-bindings-plan")
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "tools"))
+
+from test_reconcile import Stubs, SubprocessGuard, sig  # noqa: E402
+
+FAILURES = []
+CHECKS = 0
+
+RECURRENT_TITLES = [
+    "Time tracking - Sprint 104",
+    "Stand Up Calls - casanabria - Sprint 104",
+    "General Demo Kit maintenance - Sprint 104",
+    "Ana 1:1 calls - casanabria - Sprint 104",
+    "Ad-hoc Slack Questions - Sprint 104",
+]
+
+# gh subcommands that mutate GitHub. Any of these reaching the fake subprocess is
+# reported so a "read-only" claim can be checked rather than asserted.
+WRITE_VERBS = {"create", "close", "edit", "comment", "delete", "item-add", "item-edit"}
+
+
+def check(ok, label, detail=""):
+    global CHECKS
+    CHECKS += 1
+    if ok:
+        print(f"  ok   {label}")
+    else:
+        print(f"  FAIL {label}  {detail}")
+        FAILURES.append(f"{label}  {detail}")
+    return ok
+
+
+def section(title):
+    print(f"\n=== {title} ===")
+
+
+# ------------------------------------------------------------ subprocess fake --
+
+class _CP:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class FakeSubprocess:
+    """Stand-in for the ``subprocess`` *module* (swapped into sys.modules).
+
+    ``run()`` records the argv and answers from *responses* (substring match on
+    the joined command). Anything unmatched raises, so a missed stub is loud.
+    Every other attribute raises on call.
+    """
+
+    def __init__(self, responses=None):
+        self.calls = []
+        self.responses = list((responses or {}).items())
+
+    def run(self, cmd, *a, **k):
+        joined = " ".join(str(x) for x in cmd)
+        self.calls.append(list(cmd))
+        for needle, (rc, out) in self.responses:
+            if needle in joined:
+                return _CP(rc, out)
+        raise AssertionError(f"unstubbed subprocess.run: {joined}")
+
+    def __getattr__(self, name):
+        def boom(*a, **k):
+            raise AssertionError(f"subprocess.{name} called — stub missing")
+        return boom
+
+    def writes(self):
+        out = []
+        for cmd in self.calls:
+            if len(cmd) > 2 and cmd[0] == "gh" and cmd[2] in WRITE_VERBS:
+                out.append(" ".join(str(x) for x in cmd))
+        return out
+
+
+class SwapSubprocess:
+    """Temporarily replace sys.modules["subprocess"] with *fake*."""
+
+    def __init__(self, fake):
+        self.fake = fake
+
+    def __enter__(self):
+        self._saved = sys.modules["subprocess"]
+        sys.modules["subprocess"] = self.fake
+        return self.fake
+
+    def __exit__(self, *exc):
+        sys.modules["subprocess"] = self._saved
+        return False
+
+
+class McpStubs(Stubs):
+    """``Stubs`` plus the copies ``mcp_server`` bound at import time.
+
+    ``from wt import X`` creates an independent binding, so patching ``wt.X`` is
+    not enough for the four names mcp_server calls directly. ``get_all_sprints``
+    stays stubbed-but-allowed in both modes (a pure read the tools do themselves).
+    """
+
+    REBOUND = ["get_all_sprints", "get_current_sprint", "delete_github_issue",
+               "sync_project_status"]
+
+    def __init__(self, wt, mcp_server, **kw):
+        super().__init__(wt, **kw)
+        self.mcp = mcp_server
+        self._mcp_saved = {}
+
+    def __enter__(self):
+        super().__enter__()
+        self.wt.get_all_sprints = lambda d, _s=self.sprints: copy.deepcopy(_s)
+        for name in self.REBOUND:
+            self._mcp_saved[name] = getattr(self.mcp, name)
+            setattr(self.mcp, name, getattr(self.wt, name))
+        # get_current_sprint is not in GH_FUNCS; route it through the stubbed list.
+        self.mcp.get_current_sprint = lambda d: self.wt.find_sprint_for_date(
+            copy.deepcopy(self.sprints), __import__("datetime").date.today())
+        return self
+
+    def __exit__(self, *exc):
+        for name, val in self._mcp_saved.items():
+            setattr(self.mcp, name, val)
+        return super().__exit__(*exc)
+
+
+# ------------------------------------------------------------------- fixtures --
+
+def point_at(wt, mcp_server, src, dst):
+    """Copy *src* to *dst* and point **both** modules' DATA_FILE at it."""
+    dst = Path(dst)
+    live = Path.home() / ".workload_tracker.json"
+    assert dst.name.endswith(".json") and dst != live, dst
+    shutil.copyfile(src, dst)
+    os.environ["WT_DATA_FILE"] = str(dst)
+    wt.DATA_FILE = dst
+    mcp_server.DATA_FILE = dst
+    return dst
+
+
+def sprints_of(data, wt):
+    return wt.get_cached_sprints(data)
+
+
+# ----------------------------------------------------------------------- tests --
+
+def test_import_and_shape(wt, mcp_server):
+    section("1. module imports, tool registry, and no legacy imports")
+    check(mcp_server.DATA_FILE != Path.home() / ".workload_tracker.json",
+          "DATA_FILE honours WT_DATA_FILE", str(mcp_server.DATA_FILE))
+
+    for gone in ("split_cross_sprint_task", "sprint_summary_for_task",
+                 "task_logged_mins_for_sprint", "sprint_split"):
+        check(not hasattr(mcp_server, gone), f"{gone} no longer bound in mcp_server")
+    for need in ("task_current_issue", "set_task_current_issue",
+                 "clear_task_current_issue", "current_binding", "task_issue_refs",
+                 "task_reportable_mins", "task_sprints_with_time",
+                 "reconcile_task_sprints", "close_task",
+                 "_migrate_shadows_to_bindings", "sync_task_sprints"):
+        check(hasattr(mcp_server, need), f"{need} bound in mcp_server")
+
+    src = (REPO / "mcp_server.py").read_text()
+    check("cross_sprint_parent" not in src, "no cross_sprint_parent reference at all")
+
+    # The tools are plain sync functions: FastMCP's @mcp.tool() registers and
+    # returns the original function, so the module-level names are callable
+    # directly. Proved rather than assumed, since the brief asked.
+    for name in ("list_tasks", "get_task", "sync_task_sprints", "set_sprint",
+                 "set_task_status", "list_sprints", "get_current_sprint_info",
+                 "link_github_issue", "unlink_github_issue",
+                 "push_task_to_github", "get_status"):
+        fn = getattr(mcp_server, name)
+        check(callable(fn) and not inspect.iscoroutinefunction(fn),
+              f"{name} is a plain sync function (not async)")
+
+    tools = asyncio.run(mcp_server.mcp.list_tools())
+    names = {t.name for t in tools}
+    check("sync_task_sprints" in names, "sync_task_sprints registered as an MCP tool")
+    check("sprint_split" not in names, "sprint_split no longer registered")
+    schema = next(t.inputSchema for t in tools if t.name == "sync_task_sprints")
+    props = set(schema.get("properties", {}))
+    check(props == {"task_query", "all_tasks", "create_issues", "dry_run"},
+          "sync_task_sprints schema properties", str(sorted(props)))
+    print(f"       ({len(names)} tools registered)")
+    return names
+
+
+def test_load_migrates(wt, mcp_server, fixture, scratch):
+    section("2. mcp_server.load() runs the shadow->bindings migration (the fix)")
+    dst = point_at(wt, mcp_server, fixture, scratch / "premigration.json")
+    raw = json.loads(dst.read_text())
+    check(len(raw["tasks"]) == 92, "fixture starts at 92 tasks", str(len(raw["tasks"])))
+    n_shadow = sum(1 for t in raw["tasks"] if t.get("cross_sprint_parent"))
+    check(n_shadow == 12, "fixture starts with 12 shadows", str(n_shadow))
+
+    data = mcp_server.load()
+    check(len(data["tasks"]) == 80, "mcp_server.load() returns 80 tasks",
+          str(len(data["tasks"])))
+    check(not any(t.get("cross_sprint_parent") for t in data["tasks"]),
+          "no shadow survives mcp_server.load()")
+    n_bind = sum(len(t.get("sprint_issues") or []) for t in data["tasks"])
+    check(n_bind == 82, "82 bindings after mcp_server.load()", str(n_bind))
+    check(data.get("config", {}).get("sprint_bindings_migrated") is True,
+          "migration flag set")
+    # It persisted, and a second load is a no-op.
+    on_disk = json.loads(dst.read_text())
+    check(len(on_disk["tasks"]) == 80, "migration was saved to disk",
+          str(len(on_disk["tasks"])))
+    before = dst.read_text()
+    mcp_server.load()
+    check(dst.read_text() == before, "second mcp_server.load() is byte-identical")
+
+    total = sum(l.get("minutes", 0) for t in data["tasks"] for l in t.get("logs", []))
+    logs = sum(len(t.get("logs", [])) for t in data["tasks"])
+    check(abs(total - 26620.71) < 1e-6, "total minutes preserved", f"{total}")
+    check(logs == 392, "log count preserved", str(logs))
+
+
+def test_list_tasks(wt, mcp_server, migrated, scratch):
+    section("3. list_tasks — no shadow filter, filters still work")
+    point_at(wt, mcp_server, migrated, scratch / "list.json")
+    data = mcp_server.load()
+    n_all = len(data["tasks"])
+    n_done = sum(1 for t in data["tasks"] if t.get("status") == "done")
+
+    out = mcp_server.list_tasks()
+    n_default = out.count("\n  ID: ")
+    check(n_default == n_all - n_done,
+          f"default list = {n_all - n_done} non-done tasks", str(n_default))
+
+    out_all = mcp_server.list_tasks(include_done=True)
+    check(out_all.count("\n  ID: ") == n_all,
+          f"include_done=True lists all {n_all}", str(out_all.count("\n  ID: ")))
+
+    out_done = mcp_server.list_tasks(status="done")
+    check(out_done.count("\n  ID: ") == n_done,
+          f'status="done" lists {n_done}', str(out_done.count("\n  ID: ")))
+
+    out_rec = mcp_server.list_tasks(status="recurrent")
+    check(out_rec.count("\n  ID: ") == 5, 'status="recurrent" lists 5',
+          str(out_rec.count("\n  ID: ")))
+
+    role = data["tasks"][0]["role_id"]
+    n_role = sum(1 for t in data["tasks"]
+                 if t.get("role_id") == role and t.get("status") != "done")
+    out_role = mcp_server.list_tasks(role=role)
+    check(out_role.count("\n  ID: ") == n_role, f"role={role!r} filter",
+          str(out_role.count("\n  ID: ")))
+
+    check(mcp_server.list_tasks(role="nope") == "No tasks found.",
+          "unknown role -> No tasks found.")
+
+    # A previously-shadowed task's parent is visible exactly once, and none of
+    # the 12 shadow titles (parent title + " (Sprint N)") appears at all.
+    titles = [l for l in out_all.splitlines() if l and not l.startswith("  ID: ")]
+    check(titles.count("IRON Infusion") == 1,
+          "the ex-shadow parent appears exactly once",
+          str(titles.count("IRON Infusion")))
+    shadowish = [t for t in titles if t.rstrip().endswith(")") and " (Sprint " in t]
+    check(not shadowish, "no shadow-named task in the list", str(shadowish))
+
+
+def test_get_task(wt, mcp_server, migrated, scratch):
+    section("4. get_task — sprint_issues + start_sprint")
+    point_at(wt, mcp_server, migrated, scratch / "get.json")
+    data = mcp_server.load()
+    multi = max(data["tasks"], key=lambda t: len(t.get("sprint_issues") or []))
+    out = mcp_server.get_task(multi["id"])
+    print("\n".join("       " + l for l in out.splitlines()[:20]))
+    check("Start sprint:" in out, "get_task reports Start sprint")
+    check("Sprint issues (" in out, "get_task reports the sprint_issues list")
+    check("← current" in out, "get_task marks the current binding")
+    check("Logged time by sprint:" in out, "get_task reports per-sprint minutes")
+    for b in multi["sprint_issues"]:
+        if b.get("issue"):
+            check(b["issue"] in out, f"binding issue {b['issue']} shown")
+    cur = wt.task_current_issue(multi, data)
+    check(f"GitHub Issue: {cur}" in out, "GitHub Issue line uses task_current_issue",
+          cur or "None")
+    check(mcp_server.get_task("no-such-task-xyz").startswith("No task found"),
+          "get_task misses cleanly")
+
+    # A task with no bindings at all must not crash.
+    plain = {"id": "zz", "title": "no bindings here", "role_id": "other",
+             "status": "todo", "logs": [], "created_at": 0}
+    data["tasks"].append(plain)
+    mcp_server.save(data)
+    out2 = mcp_server.get_task("no bindings here")
+    check("Sprint issues (" not in out2, "task with no bindings renders without the section")
+    check("Start sprint: (unknown)" in out2, "unknown start sprint rendered")
+
+
+def test_sync_dry_run(wt, mcp_server, migrated, scratch):
+    section("5. sync_task_sprints(dry_run=True) — zero GitHub calls, zero writes")
+    dst = point_at(wt, mcp_server, migrated, scratch / "dry.json")
+    data = mcp_server.load()
+    sprints = sprints_of(data, wt)
+    disk_before = dst.read_text()
+    # By id: "IRON Infusion" is a substring of 5 other titles and mcp_server's
+    # resolve_task deliberately returns None on an ambiguous match.
+    iron = next(t for t in data["tasks"] if t["title"] == "IRON Infusion")["id"]
+
+    with McpStubs(wt, mcp_server, mode="strict", sprints=sprints) as st:
+        fake = FakeSubprocess()
+        with SwapSubprocess(fake):
+            out = mcp_server.sync_task_sprints(iron, dry_run=True)
+        check(st.count("create_github_issue") == 0, "no issue created in a dry run")
+        check(st.count("close_github_issue") == 0, "no issue closed in a dry run")
+        check(fake.calls == [], "no subprocess call in a dry run", str(fake.calls[:2]))
+    check("Dry run — nothing was changed." in out, "dry run says so")
+    check(dst.read_text() == disk_before, "data file byte-identical after a dry run")
+    print("\n".join("       " + l for l in out.splitlines()[:14]))
+    return out
+
+
+def test_requirement_a(wt, mcp_server, migrated, scratch):
+    section("6. requirement (a): all_tasks dry run plans ZERO issue creations")
+    dst = point_at(wt, mcp_server, migrated, scratch / "alldry.json")
+    data = mcp_server.load()
+    sprints = sprints_of(data, wt)
+    disk_before = dst.read_text()
+
+    with McpStubs(wt, mcp_server, mode="strict", sprints=sprints):
+        fake = FakeSubprocess()
+        with SwapSubprocess(fake):
+            out = mcp_server.sync_task_sprints(all_tasks=True, dry_run=True)
+        check(fake.calls == [], "no subprocess call", str(fake.calls[:2]))
+    check(dst.read_text() == disk_before, "data file unchanged")
+
+    # The rendered plan is the contract the caller sees.
+    check("Totals: 0 issue(s) to create" in out,
+          "all_tasks default plans 0 issue creations",
+          [l for l in out.splitlines() if l.startswith("Totals:")])
+    check("all_tasks does not create GitHub issues" in out,
+          "the opt-in is spelled out in the output")
+    unbilled = [l for l in out.splitlines() if "were NOT bound" in l]
+    check(bool(unbilled), "unbillable past sprints are reported, not silently bound",
+          str(unbilled))
+    print("       " + (unbilled[0] if unbilled else "(none)"))
+
+    # And the same assertion at the plan level, not just the rendering.
+    with McpStubs(wt, mcp_server, mode="strict", sprints=sprints):
+        creates = 0
+        for t in data["tasks"]:
+            if t.get("status") == "recurrent":
+                continue
+            res = wt.reconcile_task_sprints(t, data, sprints, create_issues=False,
+                                            dry_run=True)
+            creates += sum(1 for op in res["planned"]
+                           if op["op"] == "create" and op.get("create_issue"))
+    check(creates == 0, "plan-level: 0 create-issue ops across every task", str(creates))
+
+    # Contrast: the opt-in really would mint issues, so the default is load-bearing.
+    with McpStubs(wt, mcp_server, mode="strict", sprints=sprints):
+        fake = FakeSubprocess()
+        with SwapSubprocess(fake):
+            out2 = mcp_server.sync_task_sprints(all_tasks=True, create_issues=True,
+                                                dry_run=True)
+    n = next((l for l in out2.splitlines() if l.startswith("Totals:")), "")
+    would = int(n.split()[1]) if n else -1
+    check(would > 0, "create_issues=True WOULD mint issues (so the default matters)", n)
+    print(f"       opt-in would create {would} issue(s)")
+
+
+def test_requirement_b(wt, mcp_server, migrated, scratch):
+    section("7. requirement (b): recurrent tasks skipped and reported")
+    point_at(wt, mcp_server, migrated, scratch / "rec.json")
+    data = mcp_server.load()
+    sprints = sprints_of(data, wt)
+
+    with McpStubs(wt, mcp_server, mode="strict", sprints=sprints):
+        fake = FakeSubprocess()
+        with SwapSubprocess(fake):
+            out = mcp_server.sync_task_sprints(all_tasks=True, dry_run=True)
+    check("Skipped 5 recurrent task(s)" in out, "5 recurrent tasks reported as skipped",
+          [l for l in out.splitlines() if "Skipped" in l])
+    for title in RECURRENT_TITLES:
+        check(f"  - {title} " in out, f"named in output: {title}")
+    # And none of them appears in the plan body.
+    plan_body = out.split("Plan for", 1)[-1]
+    leaked = [t for t in RECURRENT_TITLES if f"\n  {t}" in plan_body]
+    check(not leaked, "no recurrent task appears in the plan body", str(leaked))
+
+    # Single-task form skips too.
+    with McpStubs(wt, mcp_server, mode="strict", sprints=sprints):
+        fake = FakeSubprocess()
+        with SwapSubprocess(fake):
+            one = mcp_server.sync_task_sprints("Time tracking - Sprint 104",
+                                               dry_run=True)
+    check("Skipped 1 recurrent task(s)" in one, "single recurrent task is skipped", one[:120])
+    check("Nothing to do (0 task(s)" in one, "and nothing is planned for it", one[:200])
+
+
+def test_sync_real_run(wt, mcp_server, migrated, scratch):
+    section("8. sync_task_sprints real run (fully stubbed) + idempotency")
+    dst = point_at(wt, mcp_server, migrated, scratch / "real.json")
+    data = mcp_server.load()
+    sprints = sprints_of(data, wt)
+    task = next(t for t in data["tasks"] if t["title"] == "Assist on Banco Galicia")
+    before_bindings = len(task.get("sprint_issues") or [])
+    # Compare log *content* ignoring the uploaded_at marker that
+    # mark_logs_uploaded stamps (pre-existing behaviour, not a reconcile change).
+    def logsig(t):
+        return json.dumps([{k: v for k, v in l.items() if k != "uploaded_at"}
+                           for l in t["logs"]], sort_keys=True)
+    before_logs = logsig(task)
+
+    with McpStubs(wt, mcp_server, mode="record", sprints=sprints) as st:
+        fake = FakeSubprocess()
+        with SwapSubprocess(fake):
+            out = mcp_server.sync_task_sprints("Assist on Banco Galicia")
+        created = st.count("create_github_issue")
+        closed = st.count("close_github_issue")
+    print("\n".join("       " + l for l in out.splitlines()[-10:]))
+    check("Done." in out, "real run reports Done.", out.splitlines()[-1])
+    check(created >= 1, "at least one issue minted (stub)", str(created))
+    check(closed >= 1, "at least one issue closed (stub)", str(closed))
+
+    data2 = mcp_server.load()
+    t2 = next(t for t in data2["tasks"] if t["title"] == "Assist on Banco Galicia")
+    check(len(t2["sprint_issues"]) > before_bindings,
+          "bindings grew", f"{before_bindings} -> {len(t2['sprint_issues'])}")
+    check(logsig(t2) == before_logs,
+          "logs untouched by the reconcile (bar the uploaded_at marker)")
+
+    # Idempotency: a second run has nothing to do and touches nothing.
+    disk_before = dst.read_text()
+    with McpStubs(wt, mcp_server, mode="strict", sprints=sprints) as st2:
+        fake = FakeSubprocess()
+        with SwapSubprocess(fake):
+            again = mcp_server.sync_task_sprints("Assist on Banco Galicia")
+        check(st2.count("create_github_issue") == 0, "2nd run: no GitHub write")
+        check(fake.calls == [], "2nd run: no subprocess call")
+    check("Nothing to do" in again, "2nd run reports nothing to do", again[:160])
+    check(dst.read_text() == disk_before, "2nd run leaves the file byte-identical")
+    return dst
+
+
+def test_set_sprint(wt, mcp_server, migrated, scratch):
+    section("9. set_sprint now corrects start_sprint")
+    point_at(wt, mcp_server, migrated, scratch / "setsprint.json")
+    data = mcp_server.load()
+    task = next(t for t in data["tasks"] if t["title"] == "IRON Infusion")
+    iron = task["id"]
+    old_sprint_id = task.get("sprint_id")
+    old_bindings = copy.deepcopy(task.get("sprint_issues"))
+    check(task.get("start_sprint") == "Sprint 98", "starts out on Sprint 98",
+          str(task.get("start_sprint")))
+
+    with McpStubs(wt, mcp_server, mode="strict", sprints=sprints_of(data, wt)):
+        out = mcp_server.set_sprint(iron, "Sprint 96")
+    check("now starts in Sprint 96" in out, "set_sprint says start sprint", out)
+    d2 = mcp_server.load()
+    t2 = next(t for t in d2["tasks"] if t["id"] == iron)
+    check(t2.get("start_sprint") == "Sprint 96", "start_sprint written",
+          str(t2.get("start_sprint")))
+    check(t2.get("start_sprint_id"), "start_sprint_id written")
+    check(t2.get("sprint_id") == old_sprint_id,
+          "legacy sprint_id NOT re-pointed", f"{old_sprint_id} -> {t2.get('sprint_id')}")
+    check(t2.get("sprint_issues") == old_bindings, "bindings untouched")
+
+    with McpStubs(wt, mcp_server, mode="strict", sprints=sprints_of(d2, wt)):
+        out2 = mcp_server.set_sprint(iron, "none")
+    check("Cleared the start sprint" in out2, "none clears it", out2)
+    d3 = mcp_server.load()
+    t3 = next(t for t in d3["tasks"] if t["id"] == iron)
+    check("start_sprint" not in t3 and "start_sprint_id" not in t3, "keys removed")
+
+    with McpStubs(wt, mcp_server, mode="strict", sprints=sprints_of(d3, wt)):
+        out3 = mcp_server.set_sprint(iron, "Sprint 9999")
+    check("No sprint matching" in out3, "unknown sprint rejected", out3)
+
+
+def test_close_end_to_end(wt, mcp_server, migrated, scratch):
+    section("10. set_task_status(..., 'done') end-to-end (stubbed)")
+    dst = point_at(wt, mcp_server, migrated, scratch / "close.json")
+    data = mcp_server.load()
+    sprints = sprints_of(data, wt)
+
+    # (a) an OPEN multi-sprint task: the reconcile must run inside the close, so
+    #     each earlier sprint gets its own issue and hours.
+    def unbound_count(t):
+        bound = {b.get("sprint_id") for b in t.get("sprint_issues") or []}
+        return len([e for e in wt.task_sprints_with_time(t, sprints)
+                    if e["sprint_id"] not in bound])
+    task = max((t for t in data["tasks"]
+                if t.get("status") == "inprogress" and t.get("github_repo")
+                and len(wt.task_sprints_with_time(t, sprints)) > 1),
+               key=unbound_count)
+    title, tid = task["title"], task["id"]
+    per_sprint = [e["sprint_title"] for e in wt.task_sprints_with_time(task, sprints)]
+    bound_before = {b.get("sprint_id") for b in task.get("sprint_issues") or []}
+    unbound = [e for e in wt.task_sprints_with_time(task, sprints)
+               if e["sprint_id"] not in bound_before]
+    print(f"       task={title[:52]!r} sprints={per_sprint} "
+          f"bindings={len(bound_before)} unbound={[e['sprint_title'] for e in unbound]}")
+
+    with McpStubs(wt, mcp_server, mode="strict", sprints=sprints):
+        plan = wt.reconcile_task_sprints(task, data, sprints, dry_run=True)
+    want_mints = sum(1 for op in plan["planned"]
+                     if op["op"] == "create" and op.get("create_issue"))
+    want_closes = sum(1 for op in plan["planned"] if op["op"] == "close") + 1
+
+    with McpStubs(wt, mcp_server, mode="record", sprints=sprints) as st:
+        fake = FakeSubprocess()
+        with SwapSubprocess(fake):
+            out = mcp_server.set_task_status(tid, "done")
+    print("\n".join("       " + l for l in out.splitlines()))
+    check(out.startswith(f"Closed '{title}'"), "close reports success", out[:120])
+    check(st.count("create_github_issue") == want_mints,
+          f"exactly the planned number of issues minted ({want_mints})",
+          str(st.count("create_github_issue")))
+    check(st.count("close_github_issue") == want_closes,
+          f"closes = planned past-sprint closes + 1 current = {want_closes}",
+          str(st.count("close_github_issue")))
+    check(fake.calls == [], "no raw gh subprocess call (all via wt)", str(fake.calls[:2]))
+
+    d2 = mcp_server.load()
+    t2 = next(t for t in d2["tasks"] if t["id"] == tid)
+    check(t2["status"] == "done", "task marked done", t2["status"])
+    bound_after = {b.get("sprint_id") for b in t2["sprint_issues"]}
+    missing = [e["sprint_title"] for e in wt.task_sprints_with_time(t2, sprints)
+               if e["sprint_id"] not in bound_after]
+    check(not missing, "every sprint with time now has a binding", str(missing))
+    check(all(b.get("state") == "closed" for b in t2["sprint_issues"]),
+          "every binding closed",
+          str([(b.get("sprint"), b.get("state")) for b in t2["sprint_issues"]]))
+    # Each binding's cached hours must equal that sprint's own minutes, not the
+    # task total — the double-count the plan is about.
+    bad = []
+    for b in t2["sprint_issues"]:
+        want = wt.mins_to_quarter_hours(
+            wt.task_mins_for_sprint(t2, b.get("sprint_id"), sprints))
+        if b.get("hours_synced") is None or abs(b["hours_synced"] - want) > 1e-9:
+            bad.append((b.get("sprint"), b.get("hours_synced"), want))
+    check(not bad, "each binding's hours = that sprint's own minutes", str(bad))
+    total_h = wt.mins_to_quarter_hours(wt.task_logged_mins(t2))
+    check(sum(b["hours_synced"] for b in t2["sprint_issues"]) >= total_h - 1e-9,
+          "per-sprint hours sum to >= the rounded total (round-up-per-sprint)",
+          f"{sum(b['hours_synced'] for b in t2['sprint_issues'])} vs {total_h}")
+    check("Added to project" in out, "project update reported")
+    check("Closed issue:" in out, "current issue close reported")
+
+    # (b) create_issue=False on a repo-having task with no issue must refuse.
+    d3 = mcp_server.load()
+    victim = next(t for t in d3["tasks"]
+                  if t.get("github_repo") and t.get("status") != "done"
+                  and not wt.task_current_issue(t, d3))
+    print(f"       (no-issue task: {victim['title']!r})")
+    with McpStubs(wt, mcp_server, mode="record", sprints=sprints) as st2:
+        fake = FakeSubprocess()
+        with SwapSubprocess(fake):
+            refused = mcp_server.set_task_status(victim["id"], "done")
+    check("has no GitHub issue linked" in refused, "refuses without create_issue",
+          refused[:80])
+    check(st2.count("create_github_issue") == 0, "and mints nothing",
+          str(st2.count("create_github_issue")))
+    d4 = mcp_server.load()
+    v4 = next(t for t in d4["tasks"] if t["id"] == victim["id"])
+    check(v4.get("status") != "done", "task left open", v4.get("status"))
+
+    # (c) create_issue=True mints one and closes.
+    with McpStubs(wt, mcp_server, mode="record", sprints=sprints) as st3:
+        fake = FakeSubprocess()
+        with SwapSubprocess(fake):
+            ok = mcp_server.set_task_status(victim["id"], "done", create_issue=True)
+    check(st3.count("create_github_issue") >= 1, "create_issue=True mints one",
+          str(st3.count("create_github_issue")))
+    check("Created issue:" in ok, "and reports it", ok[:120])
+    d5 = mcp_server.load()
+    v5 = next(t for t in d5["tasks"] if t["id"] == victim["id"])
+    check(v5.get("status") == "done", "now done", v5.get("status"))
+    check(wt.task_current_issue(v5, d5), "issue recorded on a binding",
+          str(v5.get("sprint_issues")))
+
+    # (d) a repo-less task closes with no GitHub interaction at all. Every task in
+    #     the real data has a repo, so make one via add_task (also exercises the
+    #     add_task binding write path).
+    with McpStubs(wt, mcp_server, mode="record", sprints=sprints):
+        created = mcp_server.add_task("harness repo-less task", role="other")
+    check("Created task" in created, "add_task created a repo-less task", created[:80])
+    with McpStubs(wt, mcp_server, mode="strict", sprints=sprints):
+        fake = FakeSubprocess()
+        with SwapSubprocess(fake):
+            plain = mcp_server.set_task_status("harness repo-less task", "done")
+    check("no repo — no GitHub integration" in plain, "repo-less close is local-only",
+          plain[:120])
+    check(fake.calls == [], "and makes no subprocess call")
+
+    # (e) a non-done status change still syncs the project via the current issue.
+    d7 = mcp_server.load()
+    todo = next(t for t in d7["tasks"]
+                if t.get("status") == "todo" and wt.task_current_issue(t, d7))
+    todo_ref = wt.task_current_issue(todo, d7)
+    with McpStubs(wt, mcp_server, mode="record", sprints=sprints) as st5:
+        fake = FakeSubprocess()
+        with SwapSubprocess(fake):
+            moved = mcp_server.set_task_status(todo["id"], "inprogress")
+    check("(project synced)" in moved, "status sync used the current binding's issue",
+          moved)
+    synced = [a for n, a, k in st5.calls if n == "sync_project_status"]
+    check(synced and synced[0][0] == todo_ref,
+          "…and with the right ref", f"{synced[:1]} want {todo_ref}")
+
+    # (f) add_task with an explicit issue records it on a binding, not just the key.
+    with McpStubs(wt, mcp_server, mode="record", sprints=sprints):
+        mcp_server.add_task("harness linked task", role="other",
+                            github_issue="grafana/field-eng#4321")
+    d8 = mcp_server.load()
+    lt = next(t for t in d8["tasks"] if t["title"] == "harness linked task")
+    check(any(b.get("issue") == "grafana/field-eng#4321"
+              for b in lt.get("sprint_issues") or []),
+          "add_task(github_issue=...) writes a binding", str(lt.get("sprint_issues")))
+    check(wt.task_current_issue(lt, d8) == "grafana/field-eng#4321",
+          "…and task_current_issue sees it")
+    return dst
+
+
+def test_link_unlink_push(wt, mcp_server, migrated, scratch):
+    section("11. link / unlink / push / notes / rename / delete")
+    point_at(wt, mcp_server, migrated, scratch / "link.json")
+    data = mcp_server.load()
+    sprints = sprints_of(data, wt)
+    task = next(t for t in data["tasks"] if t["title"] == "Compliance Week")
+    before = wt.task_current_issue(task, data)
+    print(f"       (Compliance Week current issue: {before})")
+
+    # link
+    with McpStubs(wt, mcp_server, mode="record", sprints=sprints):
+        fake = FakeSubprocess({"gh issue view": (0, json.dumps(
+            {"number": 4242, "title": "stub issue"}))})
+        with SwapSubprocess(fake):
+            out = mcp_server.link_github_issue("Compliance Week", "grafana/field-eng#4242")
+    check("Linked 'Compliance Week'" in out, "link reports success", out)
+    check(not fake.writes(), "link made no gh write call", str(fake.writes()))
+    d2 = mcp_server.load()
+    t2 = next(t for t in d2["tasks"] if t["title"] == "Compliance Week")
+    check(wt.task_current_issue(t2, d2) == "grafana/field-eng#4242",
+          "task_current_issue reflects the link", str(wt.task_current_issue(t2, d2)))
+    check(any(b.get("issue") == "grafana/field-eng#4242"
+              for b in t2.get("sprint_issues") or []),
+          "…and it landed on a binding, not just the flat key",
+          str(t2.get("sprint_issues")))
+    check(t2.get("github_issue") == "grafana/field-eng#4242",
+          "legacy mirror still written (other consumers read it)")
+
+    # unlink
+    with McpStubs(wt, mcp_server, mode="record", sprints=sprints):
+        out2 = mcp_server.unlink_github_issue("Compliance Week")
+    check("Unlinked 'Compliance Week' from grafana/field-eng#4242" in out2,
+          "unlink reports the removed ref", out2)
+    d3 = mcp_server.load()
+    t3 = next(t for t in d3["tasks"] if t["title"] == "Compliance Week")
+    check(wt.task_current_issue(t3, d3) is None, "no current issue afterwards",
+          str(wt.task_current_issue(t3, d3)))
+    check("github_issue" not in t3, "legacy key dropped")
+    check("not linked to a GitHub issue" in mcp_server.unlink_github_issue("Compliance Week"),
+          "second unlink is a clean no-op")
+
+    # unlink on a multi-binding task reports the remaining past-sprint issues
+    d4 = mcp_server.load()
+    multi = next(t for t in d4["tasks"]
+                 if len([b for b in (t.get("sprint_issues") or []) if b.get("issue")]) > 2)
+    out3 = mcp_server.unlink_github_issue(multi["id"])
+    check("Still bound to" in out3, "remaining past-sprint issues named",
+          out3.replace("\n", " | ")[:180])
+    print("       " + out3.replace("\n", " | ")[:200])
+
+    # push — hours must be the current sprint's, not the task total
+    d5 = mcp_server.load()
+    # A task whose sprint-filtered hours differ sharply from its total: IRON
+    # Infusion has 66h across 5 sprints, only 3h of which is its current sprint's.
+    ptask = next(t for t in d5["tasks"] if t["title"] == "IRON Infusion")
+    with McpStubs(wt, mcp_server, mode="record", sprints=sprints) as st:
+        fake = FakeSubprocess()
+        with SwapSubprocess(fake):
+            pout = mcp_server.push_task_to_github(ptask["id"])
+    check(pout.startswith("Pushed "), "push reports success", pout)
+    reported = float(pout.rsplit(": ", 1)[1].rstrip("h"))
+    total_h = wt.mins_to_quarter_hours(wt.task_logged_mins(ptask))
+    sprint_h = wt.mins_to_quarter_hours(wt.task_reportable_mins(ptask, sprints))
+    check(abs(reported - sprint_h) < 1e-9, "push reports the sprint-filtered hours",
+          f"reported={reported} sprint={sprint_h} total={total_h}")
+    check(reported != total_h, "…which really differs from the task total",
+          f"{reported} vs {total_h}")
+    print(f"       pushed {reported}h (task total would be {total_h}h)")
+    hours_pushed = [a[1] for n, a, k in st.calls if n == "update_project_hours"]
+    check(hours_pushed and abs(hours_pushed[-1] - sprint_h) < 1e-9,
+          "the value actually sent to GitHub matches", str(hours_pushed))
+
+    check("has no linked GitHub issue" in mcp_server.push_task_to_github("Compliance Week"),
+          "push refuses without an issue")
+
+    # get_notes_path uses the current binding
+    d6 = mcp_server.load()
+    nt = next(t for t in d6["tasks"] if wt.task_current_issue(t, d6))
+    nout = mcp_server.get_notes_path(nt["id"])
+    check(wt.task_current_issue(nt, d6) in nout, "get_notes_path names the current issue",
+          nout[:120])
+
+    # rename updates the current binding's issue title only
+    with McpStubs(wt, mcp_server, mode="record", sprints=sprints):
+        fake = FakeSubprocess({"gh issue edit": (0, "")})
+        with SwapSubprocess(fake):
+            rout = mcp_server.rename_task(nt["id"], "renamed by harness")
+    check("Updated GitHub issue" in rout, "rename updated one issue", rout)
+    edits = [c for c in fake.calls if "edit" in c]
+    check(len(edits) == 1, "exactly one gh issue edit (not one per binding)",
+          str(len(edits)))
+    want_repo, want_num = wt.task_current_issue(nt, d6).split("#")
+    check(want_repo in edits[0] and want_num in edits[0],
+          "…and it was the current issue",
+          f"{edits[0]} want {want_repo}#{want_num}")
+
+    # delete_task deletes only the current issue, names the rest
+    d7 = mcp_server.load()
+    dtask = next(t for t in d7["tasks"]
+                 if len([b for b in (t.get("sprint_issues") or []) if b.get("issue")]) > 2)
+    n_before = len(d7["tasks"])
+    with McpStubs(wt, mcp_server, mode="record", sprints=sprints) as st2:
+        dout = mcp_server.delete_task(dtask["id"])
+    check(st2.count("delete_github_issue") == 1, "exactly one issue deleted",
+          str(st2.count("delete_github_issue")))
+    check("past-sprint issue(s) left in place" in dout, "the rest are named",
+          dout.replace("\n", " | ")[:200])
+    check(len(mcp_server.load()["tasks"]) == n_before - 1, "task removed")
+
+
+def test_read_only_tools(wt, mcp_server, migrated, scratch):
+    section("12. list_sprints / get_current_sprint_info / get_status")
+    dst = point_at(wt, mcp_server, migrated, scratch / "read.json")
+    data = mcp_server.load()
+    sprints = sprints_of(data, wt)
+    disk_before = dst.read_text()
+
+    with McpStubs(wt, mcp_server, mode="strict", sprints=sprints):
+        ls = mcp_server.list_sprints()
+        info = mcp_server.get_current_sprint_info()
+        status = mcp_server.get_status()
+    check("Sprint 105" in ls and "← current" in ls, "list_sprints marks the current sprint",
+          [l for l in ls.splitlines() if "current" in l])
+    check(ls.count("\n  Sprint") == len(sprints), f"lists all {len(sprints)} sprints",
+          str(ls.count("\n  Sprint")))
+    check("Current sprint: Sprint 105" in info, "get_current_sprint_info", info[:60])
+    check("Duration: 14 days" in info, "duration derived from date objects",
+          info.replace("\n", " | "))
+    check(dst.read_text() == disk_before, "read-only tools change nothing")
+
+    # get_status total must equal the invariant total (no shadow double-count).
+    total_line = status.splitlines()[0]
+    check("80 tasks" in total_line, "get_status counts 80 tasks", total_line)
+    at = data.get("active_timer")
+    mins = sum(mcp_server.task_logged_mins(t) + mcp_server.task_live_mins(t, at)
+               for t in data["tasks"])
+    check(f"{int(mins // 60)}h" in total_line,
+          "get_status total = sum over every task (no shadow double-count)",
+          f"{total_line}  (expected {int(mins // 60)}h)")
+    logged_only = sum(l.get("minutes", 0)
+                      for t in data["tasks"] for l in t.get("logs", []))
+    check(abs(logged_only - 26620.71) < 1e-6,
+          "…and the logged part is still the invariant total", str(logged_only))
+    print(f"       (active timer contributes {mins - logged_only:.1f}m live)")
+    print(f"       {total_line}")
+
+    # Offline path: no cache-vs-live key mismatch (the old startDate KeyError).
+    with McpStubs(wt, mcp_server, mode="strict", sprints=sprints):
+        saved = wt.get_all_sprints
+        wt.get_all_sprints = lambda d: []
+        mcp_server.get_all_sprints = lambda d: []
+        try:
+            ls2 = mcp_server.list_sprints()
+            info2 = mcp_server.get_current_sprint_info()
+        finally:
+            wt.get_all_sprints = saved
+            mcp_server.get_all_sprints = saved
+    check("offline" in ls2 and "Sprint 105" in ls2,
+          "list_sprints works from the cache alone", ls2.splitlines()[0])
+    check("Current sprint: Sprint 105" in info2,
+          "get_current_sprint_info works from the cache alone", info2[:60])
+
+    # close_previous_recurrent_tasks dry run reads issues via bindings.
+    with McpStubs(wt, mcp_server, mode="strict", sprints=sprints):
+        cout = mcp_server.close_previous_recurrent_tasks(dry_run=True)
+    check("None" not in cout.replace("Nothing", ""), "dry run lists real issue refs",
+          cout.replace("\n", " | ")[:220])
+    print("       " + cout.replace("\n", " | ")[:220])
+
+
+def test_invariants(wt, worked, baseline):
+    section("13. tools/check_invariants.py on a worked-on copy")
+    env = dict(os.environ, WT_DATA_FILE=str(worked))
+    proc = real_subprocess.run(
+        [sys.executable, str(REPO / "tools" / "check_invariants.py"),
+         str(worked), str(baseline)],
+        capture_output=True, text=True, env=env)
+    head = [l for l in proc.stdout.splitlines() if "minutes=" in l]
+    print("\n".join("       " + l for l in head))
+    check(proc.returncode == 0, "check_invariants exits 0",
+          f"rc={proc.returncode} {proc.stdout[-400:]}")
+    check(any("minutes=26620.71" in l for l in head), "minutes unchanged", str(head))
+    check(any("logs=392" in l for l in head), "log count unchanged", str(head))
+
+
+def test_other_harnesses(fixture, migrated, baseline, scratch):
+    section("14. tools/test_phase3.py and tools/test_reconcile.py still pass")
+    for name in ("test_phase3.py", "test_reconcile.py"):
+        sub = scratch / name.replace(".py", "")
+        sub.mkdir(parents=True, exist_ok=True)
+        env = dict(os.environ, WT_DATA_FILE=str(sub / "unused.json"))
+        proc = real_subprocess.run(
+            [sys.executable, str(REPO / "tools" / name),
+             str(fixture), str(migrated), str(baseline), str(sub)],
+            capture_output=True, text=True, env=env)
+        tail = [l for l in proc.stdout.strip().splitlines() if "checks passed" in l]
+        print("\n".join("       " + l for l in tail[-2:]))
+        check(proc.returncode == 0, f"{name} exits 0",
+              f"rc={proc.returncode} {proc.stdout[-500:]}")
+
+
+def main():
+    if len(sys.argv) != 5:
+        print(__doc__.strip(), file=sys.stderr)
+        return 2
+    fixture, migrated, baseline, scratch = (Path(a).expanduser() for a in sys.argv[1:])
+    scratch.mkdir(parents=True, exist_ok=True)
+
+    os.environ["WT_DATA_FILE"] = str(scratch / "unused.json")
+    import wt
+    import mcp_server
+
+    live = Path.home() / ".workload_tracker.json"
+    for mod in (wt, mcp_server):
+        if mod.DATA_FILE == live:
+            print(f"REFUSING TO RUN: {mod.__name__}.DATA_FILE is the live file",
+                  file=sys.stderr)
+            return 2
+
+    test_import_and_shape(wt, mcp_server)
+    test_load_migrates(wt, mcp_server, fixture, scratch)
+    test_list_tasks(wt, mcp_server, migrated, scratch)
+    test_get_task(wt, mcp_server, migrated, scratch)
+    test_sync_dry_run(wt, mcp_server, migrated, scratch)
+    test_requirement_a(wt, mcp_server, migrated, scratch)
+    test_requirement_b(wt, mcp_server, migrated, scratch)
+    worked = test_sync_real_run(wt, mcp_server, migrated, scratch)
+    test_set_sprint(wt, mcp_server, migrated, scratch)
+    test_close_end_to_end(wt, mcp_server, migrated, scratch)
+    test_link_unlink_push(wt, mcp_server, migrated, scratch)
+    test_read_only_tools(wt, mcp_server, migrated, scratch)
+    test_invariants(wt, worked, baseline)
+    test_other_harnesses(fixture, migrated, baseline, scratch)
+
+    print(f"\n{CHECKS - len(FAILURES)}/{CHECKS} checks passed")
+    if FAILURES:
+        print(f"\n{len(FAILURES)} FAILURE(S):")
+        for f in FAILURES:
+            print(f"  x {f}")
+        return 1
+    print("All MCP Phase 3 checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_phase3.py
+++ b/tools/test_phase3.py
@@ -1,0 +1,913 @@
+#!/usr/bin/env python3
+"""Verification harness for Phase 3 of docs/plan-sprint-bindings.md (wt.py/_wt).
+
+There is no automated test suite in this repo, so this script *is* the test for
+Phase 3. It runs fully offline:
+
+  * every ``gh``-touching function in ``wt`` is monkeypatched (the ``Stubs``
+    helper is reused from ``tools/test_reconcile.py``), and ``wt.subprocess``
+    itself is swapped for a guard that raises on any attribute access, so a
+    missed stub fails loudly instead of reaching real GitHub;
+  * ``get_all_sprints`` is stubbed to the offline ``config.sprints_cache``;
+  * every run happens on a fresh copy in a scratch dir, and the script refuses
+    to start if ``WT_DATA_FILE`` resolves to the live data file.
+
+Usage:
+
+    WT_DATA_FILE=<scratch>/unused.json \\
+    venv/bin/python tools/test_phase3.py <fixture.json> <migrated.json> \\
+                                         <baseline.pristine.json> <scratch-dir>
+
+Exit status 0 when every check passes.
+"""
+import copy
+import io
+import json
+import os
+import re
+import shutil
+import subprocess as real_subprocess
+import sys
+from contextlib import redirect_stdout, redirect_stderr
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "tools"))
+
+# Reuse Phase 2's stubbing machinery verbatim so both harnesses share one
+# definition of "no GitHub call can escape".
+from test_reconcile import Stubs, SubprocessGuard, load_copy, find, sig  # noqa: E402
+
+FAILURES = []
+CHECKS = 0
+
+# The four recurrent per-sprint copies a blanket reconcile would mint issues for.
+RECURRENT_WOULD_MINT = [
+    "Time tracking - Sprint 104",
+    "Stand Up Calls - casanabria - Sprint 104",
+    "Ana 1:1 calls - casanabria - Sprint 104",
+    "Ad-hoc Slack Questions - Sprint 104",
+]
+
+
+class CliStubs(Stubs):
+    """``Stubs``, but ``get_all_sprints`` always answers from the offline cache.
+
+    Phase 2's harness called reconcile directly and passed the sprint list in, so
+    strict mode could treat ``get_all_sprints`` as a forbidden call. CLI commands
+    fetch the list themselves and it is a pure read, so here it stays
+    stubbed-but-allowed in both modes. Everything that writes to GitHub is still
+    a hard failure under ``mode="strict"``.
+    """
+
+    def __enter__(self):
+        super().__enter__()
+        self.wt.get_all_sprints = lambda d, _s=self.sprints: copy.deepcopy(_s)
+        return self
+
+
+def check(ok, label, detail=""):
+    global CHECKS
+    CHECKS += 1
+    if ok:
+        print(f"  ok   {label}")
+    else:
+        print(f"  FAIL {label}  {detail}")
+        FAILURES.append(f"{label}  {detail}")
+    return ok
+
+
+def section(title):
+    print(f"\n=== {title} ===")
+
+
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+class Answers:
+    """Scripted stand-in for builtins.input(). Records every prompt."""
+
+    def __init__(self, *answers):
+        self.answers = list(answers)
+        self.prompts = []
+
+    def __call__(self, prompt=""):
+        self.prompts.append(prompt)
+        if not self.answers:
+            raise EOFError("no scripted answer left")
+        return self.answers.pop(0)
+
+
+def docstring_and_comment_lines(src: str) -> set[int]:
+    """1-indexed line numbers of *src* that are comment or string-literal only.
+
+    Used by the static checks so a mention of a deleted flag in prose isn't
+    mistaken for live code. Tokenising beats regexes for multi-line docstrings.
+    """
+    import io as _io
+    import tokenize
+    out: set[int] = set()
+    try:
+        toks = list(tokenize.generate_tokens(_io.StringIO(src).readline))
+    except tokenize.TokenError:                       # pragma: no cover
+        return out
+    for tok in toks:
+        if tok.type in (tokenize.COMMENT, tokenize.STRING):
+            for ln in range(tok.start[0], tok.end[0] + 1):
+                out.add(ln)
+    # A line is only "prose" if it holds nothing but comment/string tokens.
+    code = {tok.start[0] for tok in toks
+            if tok.type not in (tokenize.COMMENT, tokenize.STRING, tokenize.NL,
+                                tokenize.NEWLINE, tokenize.INDENT,
+                                tokenize.DEDENT, tokenize.ENDMARKER)}
+    return out - code
+
+
+def run_cmd(wt, fn, argv, answers=None):
+    """Call a wt.cmd_* function, capturing stdout/stderr and SystemExit.
+
+    Returns (plain_text_output, exit_code_or_None).
+    """
+    import builtins
+    buf = io.StringIO()
+    saved_input = builtins.input
+    if answers is not None:
+        builtins.input = answers
+    code = None
+    try:
+        with redirect_stdout(buf), redirect_stderr(buf):
+            fn(argv)
+    except SystemExit as e:
+        code = e.code if e.code is not None else 0
+    finally:
+        builtins.input = saved_input
+    return ANSI.sub("", buf.getvalue()), code
+
+
+class Env:
+    """A fresh migrated copy + sprint stub, ready for CLI calls."""
+
+    def __init__(self, wt, migrated, path):
+        self.wt = wt
+        self.path = Path(path)
+        self.data = load_copy(wt, migrated, self.path)
+        self.sprints = wt.get_cached_sprints(self.data)
+        wt.get_all_sprints = lambda d, _s=self.sprints: copy.deepcopy(_s)
+
+    def reload(self):
+        self.data = self.wt.load()
+        return self.data
+
+    def on_disk(self):
+        return json.loads(self.path.read_text())
+
+
+# ------------------------------------------------------------------ 1. smoke --
+
+def test_cli_smoke(wt, migrated, scratch):
+    section("1. every touched CLI command runs end to end (all gh stubbed)")
+    env = Env(wt, migrated, scratch / "smoke.json")
+    before = env.path.read_text()
+
+    multi = "Assist on Banco Galicia"
+    cases = [
+        ("list", wt.cmd_list, []),
+        ("list --all", wt.cmd_list, ["--all"]),
+        ("list --role demokit", wt.cmd_list, ["--role", "demokit"]),
+        ("sprint", wt.cmd_sprint, []),
+        ("status", wt.cmd_status, []),
+        ("roles", wt.cmd_roles, []),
+        ('report --sprint "Sprint 104"', wt.cmd_report, ["--sprint", "Sprint 104"]),
+        ("report --last 14d", wt.cmd_report, ["--last", "14d"]),
+        (f"logs {multi!r}", wt.cmd_logs, [multi]),
+        ("sync-sprints --dry-run <task>", wt.cmd_sync_sprints, ["--dry-run", multi]),
+        ("sync-sprints --all --dry-run", wt.cmd_sync_sprints, ["--all", "--dry-run"]),
+        ("sync-sprints --help", wt.cmd_sync_sprints, ["--help"]),
+    ]
+    outs = {}
+    with CliStubs(wt, mode="strict", sprints=env.sprints) as st:
+        for label, fn, argv in cases:
+            out, code = run_cmd(wt, fn, argv)
+            outs[label] = out
+            ok = code in (None, 0) and "Traceback" not in out
+            check(ok, f"{label} exits cleanly",
+                  f"code={code}\n{out[-600:]}")
+        check(st.calls == [], "no GitHub call from any read-only command",
+              str(st.names()[:6]))
+    check(env.path.read_text() == before,
+          "read-only commands did not touch the data file")
+
+    # A couple of content assertions so "exits cleanly" isn't the whole story.
+    check("Current sprint: Sprint 105" in outs["sprint"],
+          "wt sprint names the current sprint", outs["sprint"][:300])
+    check("Assist on Banco Galicia" in outs[f"logs {multi!r}"],
+          "wt logs prints the task")
+    check("Sprint 95" in outs["sync-sprints --dry-run <task>"]
+          and "Dry run" in outs["sync-sprints --dry-run <task>"],
+          "sync-sprints --dry-run shows the plan and says it changed nothing",
+          outs["sync-sprints --dry-run <task>"][:800])
+    print("\n--- wt sprint ---")
+    print("\n".join("   " + l for l in outs["sprint"].strip().splitlines()[:14]))
+    print("\n--- wt sync-sprints --dry-run 'Assist on Banco Galicia' ---")
+    print("\n".join("   " + l for l in
+                    outs["sync-sprints --dry-run <task>"].strip().splitlines()))
+
+
+# -------------------------------------------------- 2. wt sprint offline fix --
+
+def test_sprint_offline(wt, migrated, scratch):
+    section("2. wt sprint works from the cache alone (the camelCase KeyError)")
+    env = Env(wt, migrated, scratch / "sprintoff.json")
+
+    # Pre-Phase-3 cmd_sprint read current["startDate"]/["duration"], which only
+    # the live get_all_sprints() fetch emits. Prove a cache-shaped sprint dict
+    # (exactly what get_cached_sprints returns) no longer raises.
+    cached = wt.get_cached_sprints(env.data)
+    check(all("startDate" not in s and "duration" not in s for s in cached),
+          "cached sprint dicts really lack the camelCase keys")
+
+    with CliStubs(wt, mode="strict", sprints=env.sprints):
+        wt.get_all_sprints = lambda d: []          # simulate no network at all
+        out, code = run_cmd(wt, wt.cmd_sprint, [])
+    wt.get_all_sprints = lambda d, _s=env.sprints: copy.deepcopy(_s)
+    check(code in (None, 0) and "KeyError" not in out,
+          "wt sprint survives get_all_sprints() == [] by using the cache",
+          f"code={code}\n{out[:400]}")
+    check("offline" in out and "Sprint 105" in out,
+          "…and says it is offline", out[:300])
+    print("\n".join("   " + l for l in out.strip().splitlines()[:8]))
+
+
+# ------------------------------------------------------- 3. requirement (a) --
+
+def test_all_creates_nothing(wt, migrated, scratch):
+    section("3. requirement (a): --all mints no issues without --create-issues")
+    env = Env(wt, migrated, scratch / "all.json")
+    answers = Answers("y")
+
+    with CliStubs(wt, mode="record", sprints=env.sprints) as st:
+        out, code = run_cmd(wt, wt.cmd_sync_sprints, ["--all", "--yes"], answers)
+        creates = st.count("create_github_issue")
+        closes = st.count("close_github_issue")
+    check(code in (None, 0), f"sync-sprints --all exits cleanly (code={code})",
+          out[-800:])
+    check(creates == 0, "ZERO create_github_issue calls", f"got {creates}")
+    hour_calls = st.count("update_project_hours")
+    print(f"    stubbed gh calls: create_github_issue={creates}, "
+          f"close_github_issue={closes}, update_project_hours={hour_calls}, "
+          f"total={len(st.calls)}")
+    # closes==0 is expected and correct here: on this data every close op the
+    # Phase-2 blanket reconcile emitted was closing an issue it had *just*
+    # minted (created=25, closed=25), so with create_issues=False there is
+    # nothing new to close. The useful work --all still does is hours.
+    check(hour_calls > 0, "…but hours were still synced (the point of --all)",
+          f"got {hour_calls}")
+
+    # An issue-less binding counts as "already bound", so a later --create-issues
+    # run could never mint the issue that sprint needs. --all must therefore not
+    # *add* any. Two already exist in the migrated fixture (Phase 1 seeded them
+    # from tasks that have a sprint_id but were never linked to an issue), so the
+    # assertion is "no new ones", measured against the input.
+    def issueless(d):
+        return {(t["id"], b.get("sprint_id")) for t in d["tasks"]
+                for b in (t.get("sprint_issues") or []) if not b.get("issue")}
+
+    pre = issueless(json.loads(Path(migrated).read_text()))
+    post = issueless(env.reload())
+    check(post <= pre,
+          "--all added no issue-less 'placeholder' binding (would block a later "
+          "--create-issues run)", str(sorted(post - pre)[:5]))
+    print(f"    issue-less bindings: {len(pre)} before, {len(post)} after "
+          f"(pre-existing, from the Phase 1 migration)")
+    check("--create-issues" in out,
+          "output tells the user how to mint the missing issues")
+    unbilled = [l for l in out.splitlines() if "--create-issues" in l and "SKIP" in l]
+    print(f"    {len(unbilled)} sprint(s) reported as needing an issue, e.g.:")
+    for l in unbilled[:4]:
+        print(f"      {l.strip()}")
+    check(bool(unbilled), "the skipped past sprints are itemised, not silently dropped")
+
+    # And with --create-issues it *does* mint them — same run, second pass.
+    with CliStubs(wt, mode="record", sprints=env.sprints) as st2:
+        out2, code2 = run_cmd(wt, wt.cmd_sync_sprints,
+                              ["--all", "--create-issues", "--yes"], Answers("y"))
+        creates2 = st2.count("create_github_issue")
+    check(code2 in (None, 0), f"--all --create-issues exits cleanly (code={code2})",
+          out2[-600:])
+    check(creates2 > 0, "--create-issues does mint the previously-skipped issues",
+          f"got {creates2}")
+    print(f"    with --create-issues: create_github_issue={creates2}")
+
+    # Third pass: nothing left.
+    with CliStubs(wt, mode="strict", sprints=env.sprints) as st3:
+        out3, code3 = run_cmd(wt, wt.cmd_sync_sprints,
+                              ["--all", "--create-issues", "--dry-run"])
+        check(st3.calls == [], "a follow-up dry run makes no GitHub call")
+    check("Nothing to do" in out3,
+          "after --create-issues the plan is empty", out3[-400:])
+
+
+# ------------------------------------------------------- 4. requirement (b) --
+
+def test_recurrent_skipped(wt, migrated, scratch):
+    section("4. requirement (b): recurrent tasks are skipped and reported")
+    env = Env(wt, migrated, scratch / "rec.json")
+    recurrent = [t for t in env.data["tasks"] if t.get("status") == "recurrent"]
+    print(f"    {len(recurrent)} recurrent task(s) in the data:")
+    for t in recurrent:
+        print(f"      • {t['title']}  [{t.get('sprint')}]")
+
+    # Which of them a blanket reconcile *would* mint issues for, unskipped.
+    would = []
+    with CliStubs(wt, mode="strict", sprints=env.sprints):
+        for t in recurrent:
+            r = wt.reconcile_task_sprints(t, env.data, env.sprints, dry_run=True)
+            if any(o["op"] == "create" and o["create_issue"] for o in r["planned"]):
+                would.append(t["title"])
+    check(sorted(would) == sorted(RECURRENT_WOULD_MINT),
+          "the 4 recurrent copies an unskipped reconcile would mint issues for",
+          f"got {sorted(would)}")
+    for title in RECURRENT_WOULD_MINT:
+        print(f"      would mint: {title}")
+
+    with CliStubs(wt, mode="record", sprints=env.sprints) as st:
+        out, _ = run_cmd(wt, wt.cmd_sync_sprints,
+                         ["--all", "--create-issues", "--yes"], Answers("y"))
+        created_titles = [a[0].get("title") for n, a, k in st.calls
+                          if n == "create_github_issue"]
+    plain = out
+    for title in RECURRENT_WOULD_MINT:
+        check(re.search(rf"•\s+{re.escape(title)}\b.*recurrent", plain) is not None,
+              f"reported as skipped: {title}",
+              [l for l in plain.splitlines() if title in l][:2])
+    leaked = [t for t in created_titles
+              if any(t and t.startswith(r) for r in RECURRENT_WOULD_MINT)]
+    check(not leaked,
+          "no issue minted for any task whose status is 'recurrent', even with "
+          "--create-issues", str(leaked))
+    # For the record: *closed* per-sprint copies of a recurring series (status
+    # 'done', so not skipped) do get past-sprint issues under --create-issues.
+    # That is the plan §1.6 "leaking logs" data, and it is opt-in behind an
+    # itemised plan + confirmation, so it is treated as ordinary cross-sprint work.
+    closed_copies = [t for t in created_titles
+                     if t and re.search(r" - Sprint \d+ \(Sprint \d+\)$", t)]
+    print(f"    NOTE: {len(closed_copies)} issue(s) for CLOSED prior-sprint copies "
+          f"of recurring series (status='done', not skipped): {closed_copies}")
+    check(all(t.get("status") == "recurrent"
+              for t in env.reload()["tasks"]
+              if t["title"] in RECURRENT_WOULD_MINT),
+          "the recurrent tasks were not otherwise mutated")
+
+    # Naming one explicitly is skipped too, with an explanation.
+    env2 = Env(wt, migrated, scratch / "rec2.json")
+    with CliStubs(wt, mode="strict", sprints=env2.sprints) as st2:
+        out2, code2 = run_cmd(wt, wt.cmd_sync_sprints,
+                              ["--dry-run", "Ana 1:1 calls - casanabria - Sprint 104"])
+        check(st2.calls == [], "explicit recurrent target makes no GitHub call")
+    check("recurrent" in out2 and "Nothing to do" in out2,
+          "an explicitly named recurrent task is skipped with a reason",
+          out2[:500])
+    print("\n".join("   " + l for l in out2.strip().splitlines()))
+
+
+# ------------------------------------------------------- 5. deprecated alias --
+
+def test_split_sprint_alias(wt, migrated, scratch):
+    section("5. `wt split-sprint` still works and warns")
+    env = Env(wt, migrated, scratch / "alias.json")
+    with CliStubs(wt, mode="strict", sprints=env.sprints) as st:
+        out, code = run_cmd(wt, wt.cmd_split_sprint,
+                            ["--dry-run", "Assist on Banco Galicia"])
+        check(st.calls == [], "alias dry run makes no GitHub call")
+    check(code in (None, 0), f"alias exits cleanly (code={code})", out[-400:])
+    first = out.strip().splitlines()[0]
+    check("deprecated" in first and "sync-sprints" in first,
+          "prints a one-line deprecation notice first", repr(first))
+    check("Sprint 95" in out, "and then renders the sync-sprints plan")
+    check(wt.COMMANDS["split-sprint"] is wt.cmd_split_sprint
+          and wt.COMMANDS["sync-sprints"] is wt.cmd_sync_sprints,
+          "both names are wired into COMMANDS")
+    print(f"    {first}")
+
+
+# ------------------------------------------------------------ 6. idempotency --
+
+def test_idempotent(wt, migrated, scratch):
+    section("6. sync-sprints twice → the second run has nothing to do")
+    env = Env(wt, migrated, scratch / "idem.json")
+    task = "Assist on Banco Galicia"
+
+    with CliStubs(wt, mode="record", sprints=env.sprints) as st:
+        out1, code1 = run_cmd(wt, wt.cmd_sync_sprints, [task, "--yes"], Answers("y"))
+        n1 = len(st.calls)
+    check(code1 in (None, 0), f"run 1 exits cleanly (code={code1})", out1[-600:])
+    print(f"    run 1: {n1} stubbed gh calls")
+    print("\n".join("   " + l for l in out1.strip().splitlines()[-8:]))
+
+    after1 = env.path.read_text()
+    with CliStubs(wt, mode="strict", sprints=env.sprints) as st2:
+        out2, code2 = run_cmd(wt, wt.cmd_sync_sprints, [task, "--yes"], Answers("y"))
+        check(st2.calls == [], "run 2 makes zero GitHub calls", str(st2.names()))
+    check("Nothing to do" in out2, "run 2 reports nothing to do", out2[-400:])
+    check(env.path.read_text() == after1, "run 2 leaves the data file untouched")
+
+    # Same for --all.
+    with CliStubs(wt, mode="record", sprints=env.sprints):
+        run_cmd(wt, wt.cmd_sync_sprints, ["--all", "--create-issues", "--yes"],
+                Answers("y"))
+    after_all = env.path.read_text()
+    with CliStubs(wt, mode="strict", sprints=env.sprints) as st4:
+        out4, _ = run_cmd(wt, wt.cmd_sync_sprints,
+                          ["--all", "--create-issues", "--yes"], Answers("y"))
+        check(st4.calls == [], "a repeated --all makes zero GitHub calls",
+              str(st4.names()[:5]))
+    check("Nothing to do" in out4, "repeated --all reports nothing to do",
+          out4[-300:])
+    check(env.path.read_text() == after_all, "…and changes nothing on disk")
+    return env.path
+
+
+# ------------------------------------------------------- 7. set-sprint / done --
+
+def test_set_sprint(wt, migrated, scratch):
+    section("7. wt set-sprint now corrects the START sprint")
+    env = Env(wt, migrated, scratch / "setsprint.json")
+    task = find(env.data, "Assist on Banco Galicia")
+    tid = task["id"]
+    before = {k: task.get(k) for k in ("sprint", "sprint_id",
+                                       "start_sprint", "start_sprint_id")}
+    print(f"    before: {before}")
+
+    with CliStubs(wt, mode="strict", sprints=env.sprints) as st:
+        out, code = run_cmd(wt, wt.cmd_set_sprint, [tid, "Sprint 99"])
+        check(st.calls == [], "set-sprint makes no GitHub call")
+    check(code in (None, 0), f"exits cleanly (code={code})", out)
+    t = next(x for x in env.reload()["tasks"] if x["id"] == tid)
+    check(t.get("start_sprint") == "Sprint 99", "start_sprint written",
+          str(t.get("start_sprint")))
+    check(t.get("start_sprint_id") == next(s["id"] for s in env.sprints
+                                           if s["title"] == "Sprint 99"),
+          "start_sprint_id written", str(t.get("start_sprint_id")))
+    check(t.get("sprint") == before["sprint"] and t.get("sprint_id") == before["sprint_id"],
+          "the reconcile-owned sprint/sprint_id pointer is left alone",
+          f"{t.get('sprint')} / {t.get('sprint_id')}")
+    check("sync-sprints" in out, "output points at sync-sprints for hours", out)
+    print("\n".join("   " + l for l in out.strip().splitlines()))
+
+    # `none` clears it.
+    with CliStubs(wt, mode="strict", sprints=env.sprints):
+        out2, code2 = run_cmd(wt, wt.cmd_set_sprint, [tid, "none"])
+    t = next(x for x in env.reload()["tasks"] if x["id"] == tid)
+    check(code2 in (None, 0) and "start_sprint" not in t and "start_sprint_id" not in t,
+          "set-sprint <task> none clears both start-sprint keys",
+          f"code={code2} keys={[k for k in t if 'start' in k]}\n{out2}")
+    check("Cleared start sprint" in out2, "…and says so", out2)
+
+    # wt sprint surfaces the carry-over marker. Needs an *open* task, since
+    # cmd_sprint only lists non-done tasks.
+    open_task = find(env.data, "CI Check to read Demo Blocks content and verify if "
+                               "the change would break the demo block")
+    otid = open_task["id"]
+    with CliStubs(wt, mode="strict", sprints=env.sprints):
+        run_cmd(wt, wt.cmd_set_sprint, [otid, "Sprint 90"])
+        out3, _ = run_cmd(wt, wt.cmd_sprint, [])
+    line = next((l for l in out3.splitlines() if "CI Check" in l), "")
+    check("started Sprint 90" in line,
+          "wt sprint shows 'started Sprint N' for a carry-over", repr(line))
+    print("   " + line.strip())
+
+    # A start sprint *later* than the group sprint is not a carry-over.
+    with CliStubs(wt, mode="strict", sprints=env.sprints):
+        run_cmd(wt, wt.cmd_set_sprint, [otid, "Sprint 111"])
+        out4, _ = run_cmd(wt, wt.cmd_sprint, [])
+    line4 = next((l for l in out4.splitlines() if "CI Check" in l), "")
+    check("started" not in line4,
+          "…and not for a start sprint that is later than the group sprint",
+          repr(line4))
+    print("   " + line4.strip())
+
+
+def test_done(wt, migrated, scratch):
+    section("8. wt done renders the reconcile result (fully stubbed)")
+    env = Env(wt, migrated, scratch / "done.json")
+    task = find(env.data, "CI Check to read Demo Blocks content and verify if the "
+                          "change would break the demo block")
+    tid, issue = task["id"], wt.task_current_issue(task, env.data)
+    print(f"    task status={task['status']}  issue={issue}")
+    print(f"    sprints with time: "
+          + ", ".join(f"{e['sprint_title']}={e['total_mins']:.0f}m"
+                      for e in wt.task_sprints_with_time(task, env.sprints)))
+
+    with CliStubs(wt, mode="record", sprints=env.sprints) as st:
+        out, code = run_cmd(wt, wt.cmd_done, [tid], Answers("y", ""))
+        creates = st.count("create_github_issue")
+        closes = st.count("close_github_issue")
+    check(code in (None, 0), f"wt done exits cleanly (code={code})", out[-800:])
+    print("\n".join("   " + l for l in out.strip().splitlines()))
+    t = next(x for x in env.reload()["tasks"] if x["id"] == tid)
+    check(t["status"] == "done", "task marked done")
+    check("Closed:" in out, "prints the close line")
+    check(any(l.strip().startswith(("+", "x", "=", "→", ".")) for l in out.splitlines()),
+          "renders reconcile outcome lines instead of the old 'Split:' breakdown",
+          out)
+    check("Split:" not in out, "the old split breakdown wording is gone")
+    check("Sprint:" in out, "reports which sprint the hours went to")
+    print(f"    stubbed: create_github_issue={creates}, close_github_issue={closes}")
+    check(closes >= 1, "the task's own issue was closed", str(closes))
+    check(all("cross_sprint_parent" not in x for x in env.reload()["tasks"]),
+          "no shadow task object created")
+    check(len(env.reload()["tasks"]) == 80, "no task added or removed",
+          str(len(env.reload()["tasks"])))
+
+    # close_task's documented return keys must survive.
+    env2 = Env(wt, migrated, scratch / "done2.json")
+    t2 = find(env2.data, "Move demo block scripts to the new field-eng-demo-blocks repo")
+    with CliStubs(wt, mode="record", sprints=env2.sprints):
+        res = wt.close_task(t2, env2.data, wt.save)
+    required = {"success", "issue_created", "issue_closed", "project_updated",
+                "skipped_github", "comment_added", "split_performed",
+                "split_result", "error"}
+    check(required <= set(res), "close_task keeps every documented return key",
+          str(sorted(required - set(res))))
+    check(res["success"] is True, "close_task succeeded", str(res["error"]))
+    sr = res["split_result"] or {}
+    check("sprint_tasks_created" in sr and "main_sprint" in sr,
+          "split_result still carries the legacy render keys", str(sorted(sr))[:300])
+    print(f"    split_performed={res['split_performed']}  "
+          f"main_sprint={sr.get('main_sprint')}  "
+          f"sprint_tasks_created={[(e.get('sprint'), e.get('issue_ref')) for e in sr.get('sprint_tasks_created', [])]}")
+
+    # A task with no repo still short-circuits.
+    env3 = Env(wt, migrated, scratch / "done3.json")
+    norepo = next((t for t in env3.data["tasks"]
+                   if not wt.get_task_repo(t) and t.get("status") != "done"), None)
+    if norepo is None:
+        # Every open task in this fixture has a repo, so synthesize the case.
+        norepo = {"id": wt.uid(), "title": "Synthetic repo-less task",
+                  "description": "", "role_id": "other", "status": "inprogress",
+                  "created_at": 1, "logs": [], "sprint_issues": []}
+        env3.data["tasks"].append(norepo)
+        print("    (no repo-less open task in the fixture — synthesized one)")
+    with CliStubs(wt, mode="strict", sprints=env3.sprints) as st3:
+        res3 = wt.close_task(norepo, env3.data, wt.save)
+        check(st3.calls == [], "repo-less close makes no GitHub call")
+    check(res3["success"] and res3["skipped_github"] and norepo["status"] == "done",
+          "repo-less task closes locally with skipped_github", str(res3))
+
+
+# --------------------------------------------------------- 9. link/unlink/etc --
+
+def test_issue_routing(wt, migrated, scratch):
+    section("9. github_issue reads/writes go through the binding accessors")
+    env = Env(wt, migrated, scratch / "route.json")
+
+    # Static check: no read of task["github_issue"] outside the accessor layer.
+    src = (REPO / "wt.py").read_text().splitlines()
+    allowed_fns = {
+        "_shadow_binding", "_legacy_binding_for_task", "task_current_issue",
+        "task_issue_refs", "set_task_current_issue", "clear_task_current_issue",
+        "_reconcile_plan", "reconcile_task_sprints",
+    }
+    cur = None
+    offenders = []
+    for i, line in enumerate(src, 1):
+        m = re.match(r"def (\w+)", line)
+        if m:
+            cur = m.group(1)
+        if re.search(r"""(?<!_)\b(task|t|shadow)(\.get\(["']github_issue|\[["']github_issue)""",
+                     line) and not line.lstrip().startswith(("#", "*")):
+            if cur not in allowed_fns:
+                offenders.append(f"{i}: {cur}: {line.strip()}")
+    check(not offenders,
+          "no wt.py function outside the accessor layer touches "
+          "task['github_issue'] directly", "\n      ".join(offenders))
+    print(f"    accessor layer: {', '.join(sorted(allowed_fns))}")
+
+    # link → binding + legacy mirror; unlink → both cleared. IRON Infusion has
+    # five bindings, so it also exercises "past-sprint issues left behind".
+    task = find(env.data, "IRON Infusion")
+    tid = task["id"]
+    n_bindings = len(task["sprint_issues"])
+    check(n_bindings > 1, "the test task really has multiple bindings",
+          str(n_bindings))
+    with CliStubs(wt, mode="record", sprints=env.sprints) as st:
+        out, code = run_cmd(wt, wt.cmd_unlink, [tid])
+    t = next(x for x in env.reload()["tasks"] if x["id"] == tid)
+    check(code in (None, 0), f"unlink exits cleanly (code={code})", out)
+    check("github_issue" not in t, "legacy key removed")
+    check(wt.task_current_issue(t, env.data) is None,
+          "task_current_issue() now returns None",
+          str(wt.task_current_issue(t, env.data)))
+    check(len(t["sprint_issues"]) == n_bindings,
+          "the binding itself is kept (bindings are never deleted)",
+          f"{len(t['sprint_issues'])} vs {n_bindings}")
+    check("Still bound to" in out, "unlink names the past-sprint issues left behind",
+          out)
+    print("\n".join("   " + l for l in out.strip().splitlines()))
+
+    # relink
+    with CliStubs(wt, mode="record", sprints=env.sprints) as st:
+        wt.subprocess = FakeGhLink()          # cmd_link shells out directly
+        out2, code2 = run_cmd(wt, wt.cmd_link, [tid, "grafana/field-eng#5238"])
+    t = next(x for x in env.reload()["tasks"] if x["id"] == tid)
+    check(code2 in (None, 0), f"link exits cleanly (code={code2})", out2)
+    check(t.get("github_issue") == "grafana/field-eng#5238", "legacy mirror written",
+          str(t.get("github_issue")))
+    check(wt.task_current_issue(t, env.data) == "grafana/field-eng#5238",
+          "and the binding carries it too")
+    binding = wt._find_binding(t["sprint_issues"], issue="grafana/field-eng#5238")
+    check(binding is not None and binding.get("sprint_id") == t.get("sprint_id"),
+          "the issue landed on the binding for the task's own sprint",
+          str(binding))
+
+    # cmd_list's '#' marker follows the binding, not the legacy key.
+    env2 = Env(wt, migrated, scratch / "route2.json")
+    t2 = find(env2.data, "IRON Infusion")
+    ref = t2.pop("github_issue")          # binding-only, as a future phase will be
+    wt.save(env2.data)
+    with CliStubs(wt, mode="strict", sprints=env2.sprints):
+        out3, _ = run_cmd(wt, wt.cmd_list, ["--all"])
+    line = next((l for l in out3.splitlines() if "IRON Infusion" in l), "")
+    check("#" in line, "wt list still shows the '#' issue marker with no legacy key",
+          repr(line))
+    check(wt.task_current_issue(t2, env2.data) == ref,
+          "task_current_issue reads it from the binding", str(ref))
+    print(f"    binding-only task renders as: {line.strip()[:70]}")
+
+
+class FakeGhLink:
+    """Minimal `gh issue view --json number,title` stand-in for cmd_link."""
+
+    def run(self, argv, **kw):
+        class R:
+            returncode = 0
+            stdout = json.dumps({"number": 5238, "title": "IRON Infusion"})
+            stderr = ""
+        return R()
+
+    def __getattr__(self, name):
+        def boom(*a, **k):
+            raise AssertionError(f"wt.subprocess.{name} called: {a!r}")
+        return boom
+
+
+# ------------------------------------------------------ 10. shadow plumbing --
+
+def test_shadow_plumbing_gone(wt, migrated, scratch):
+    section("10. shadow plumbing deleted, migration sweep intact")
+    src = (REPO / "wt.py").read_text()
+
+    # Every remaining cross_sprint_parent mention must be inside the migration
+    # (the every-load shadow sweep, which is the iCloud defence and stays) — and
+    # anywhere else it may only appear in prose, never in a live code line.
+    lines = src.splitlines()
+    mig_start = next(i for i, l in enumerate(lines)
+                     if l.startswith("def _migrate_shadows_to_bindings"))
+    mig_end = next(i for i, l in enumerate(lines)
+                   if l.startswith("def resolve_task_by_id"))
+    doc = docstring_and_comment_lines(src)
+    outside = [f"{i + 1}: {lines[i].strip()}"
+               for i in range(len(lines))
+               if "cross_sprint_parent" in lines[i]
+               and not (mig_start <= i < mig_end)
+               and (i + 1) not in doc]
+    check(not outside,
+          "no live cross_sprint_parent filter/guard outside the migration",
+          "\n      ".join(outside))
+    print(f"    cross_sprint_parent survives only inside "
+          f"_migrate_shadows_to_bindings (wt.py lines {mig_start + 1}-{mig_end})")
+    check("existing_split_sprint_ids" not in src,
+          "existing_split_sprint_ids is gone")
+    check(not hasattr(wt, "existing_split_sprint_ids"),
+          "…and is not importable")
+    flag_lines = [f"{i + 1}: {lines[i].strip()}" for i in range(len(lines))
+                  if "--shadows" in lines[i] and (i + 1) not in doc]
+    check(not flag_lines,
+          "the `wt list --shadows` flag is gone from live code",
+          "\n      ".join(flag_lines))
+    check("--shadows" not in (REPO / "_wt").read_text(),
+          "_wt never had a --shadows entry and still doesn't")
+
+    # `wt list --shadows` is now just an ignored arg, not a crash.
+    env = Env(wt, migrated, scratch / "shadow.json")
+    with CliStubs(wt, mode="strict", sprints=env.sprints):
+        out_plain, _ = run_cmd(wt, wt.cmd_list, [])
+        out_flag, code = run_cmd(wt, wt.cmd_list, ["--shadows"])
+    check(code in (None, 0) and out_flag == out_plain,
+          "`wt list --shadows` no longer changes anything", f"code={code}")
+
+    # The every-load sweep still strips a re-introduced shadow (iCloud defence).
+    raw = json.loads(Path(migrated).read_text())
+    parent = next(t for t in raw["tasks"] if t["title"] == "IRON Infusion")
+    raw["tasks"].append({
+        "id": "99999999999999zzzz", "title": "IRON Infusion (Sprint 97)",
+        "description": "", "role_id": parent["role_id"], "status": "done",
+        "cross_sprint_parent": parent["id"],
+        "sprint": "Sprint 97", "sprint_id": next(
+            s["id"] for s in env.sprints if s["title"] == "Sprint 97"),
+        "github_issue": "grafana/field-eng#99999",
+        "created_at": 1, "logs": [{"id": "l1", "minutes": 120,
+                                   "note": "Sprint split: 2h from IRON Infusion",
+                                   "at": 1}],
+    })
+    inj = scratch / "reinjected.json"
+    inj.write_text(json.dumps(raw))
+    os.environ["WT_DATA_FILE"] = str(inj)
+    wt.DATA_FILE = inj
+    swept = wt.load()
+    check(not any(t.get("cross_sprint_parent") for t in swept["tasks"]),
+          "a re-introduced shadow is stripped on load")
+    p = next(t for t in swept["tasks"] if t["title"] == "IRON Infusion")
+    b = next((x for x in p["sprint_issues"] if x.get("sprint") == "Sprint 97"), None)
+    check(b is not None and b["issue"] == "grafana/field-eng#99999"
+          and b["state"] == "closed" and b["hours_synced"] == 2.0,
+          "…and converted into a binding on its parent with the right hours",
+          str(b))
+    print(f"    swept shadow → binding {b}")
+
+
+# ---------------------------------------------------------- 11. invariants --
+
+def test_invariants(wt, work, baseline):
+    section("11. tools/check_invariants.py after the CLI runs")
+    proc = real_subprocess.run(
+        [sys.executable, str(REPO / "tools" / "check_invariants.py"),
+         str(work), str(baseline)],
+        capture_output=True, text=True)
+    print("\n".join("    " + l for l in proc.stdout.strip().splitlines()))
+    if proc.stderr.strip():
+        print("    stderr:", proc.stderr.strip()[:400])
+    check(proc.returncode == 0, "check_invariants exits 0", f"rc={proc.returncode}")
+    m = re.search(r"minutes=([\d.]+)\s+logs=(\d+)", proc.stdout)
+    check(bool(m) and m.group(1) == "26620.71" and m.group(2) == "392",
+          "minutes 26620.71 and 392 logs, unchanged",
+          m.group(0) if m else proc.stdout[:200])
+
+
+def test_creation_paths(wt, migrated, scratch):
+    section("11b. task-creation paths write both the binding and the legacy key")
+    env = Env(wt, migrated, scratch / "create.json")
+    current = wt.find_sprint_for_date(env.sprints, __import__("datetime").date.today())
+
+    def one_binding(t, label):
+        b = t.get("sprint_issues") or []
+        issue = wt.task_current_issue(t, env.data)
+        check(len(b) == 1 and b[0].get("issue") == issue
+              and b[0].get("sprint_id") == t.get("sprint_id")
+              and t.get("github_issue") == issue,
+              f"{label}: exactly one binding, issue on it and mirrored to the "
+              f"legacy key", json.dumps(b, default=str) + f" legacy={t.get('github_issue')}")
+        return issue
+
+    # wt add --create-issue
+    with CliStubs(wt, mode="record", sprints=env.sprints) as st:
+        out, code = run_cmd(wt, wt.cmd_add,
+                            ["Phase3 synthetic add", "--role", "other",
+                             "--repo", "grafana/field-eng", "--create-issue"])
+    check(code in (None, 0), f"wt add --create-issue exits cleanly (code={code})", out)
+    t = next(x for x in env.reload()["tasks"] if x["title"] == "Phase3 synthetic add")
+    ref = one_binding(t, "wt add --create-issue")
+    check(t.get("sprint_id") == (current or {}).get("id"),
+          "…on the current sprint's binding", str(t.get("sprint")))
+    print(f"    wt add → {ref} on {t.get('sprint')}")
+
+    # wt add-issue / create_task_from_issue
+    env2 = Env(wt, migrated, scratch / "create2.json")
+    with CliStubs(wt, mode="record", sprints=env2.sprints):
+        wt.subprocess = FakeGhAddIssue()
+        res = wt.create_task_from_issue(env2.data, "grafana/field-eng#77777",
+                                        role_id="other")
+    check(res["error"] is None and res["task"] is not None,
+          "create_task_from_issue succeeded", str(res.get("error")))
+    one_binding(res["task"], "create_task_from_issue")
+    # …and it dedupes on the binding, not just the legacy key.
+    res["task"].pop("github_issue")
+    with CliStubs(wt, mode="record", sprints=env2.sprints):
+        wt.subprocess = FakeGhAddIssue()
+        again = wt.create_task_from_issue(env2.data, "grafana/field-eng#77777",
+                                          role_id="other")
+    check(again["existed"] is True and again["task"] is res["task"],
+          "…and dedupes off the binding even with no legacy key", str(again))
+
+    # new-recurrent
+    env3 = Env(wt, migrated, scratch / "create3.json")
+    with CliStubs(wt, mode="record", sprints=env3.sprints):
+        summary = wt.create_current_sprint_recurrent_tasks(env3.data, wt.save)
+    made = [r for r in summary["results"] if r.get("issue")]
+    check(summary["error"] is None and made,
+          "new-recurrent created tasks with issues", str(summary)[:300])
+    for r in made[:3]:
+        t = next(x for x in env3.data["tasks"] if x["title"] == r["title"])
+        one_binding(t, f"new-recurrent {r['title'][:28]!r}")
+
+
+class FakeGhAddIssue:
+    """`gh issue view --json number,title,state,url` stand-in."""
+
+    def run(self, argv, **kw):
+        class R:
+            returncode = 0
+            stdout = json.dumps({"number": 77777, "title": "Phase3 synthetic issue",
+                                 "state": "OPEN", "url": "https://example/77777"})
+            stderr = ""
+        return R()
+
+    def __getattr__(self, name):
+        def boom(*a, **k):
+            raise AssertionError(f"wt.subprocess.{name} called: {a!r}")
+        return boom
+
+
+def test_close_task_github_diff(migrated, scratch):
+    section("12. close_task's GitHub writes vs pre-Phase-3 (Option A assertion)")
+    old = scratch / "wt_pre_phase3.py"
+    proc = real_subprocess.run(["git", "show", "HEAD:wt.py"],
+                               cwd=REPO, capture_output=True, text=True)
+    if proc.returncode != 0:
+        check(False, "could not extract HEAD:wt.py for the comparison",
+              proc.stderr.strip()[:200])
+        return
+    old.write_text(proc.stdout)
+    sub = scratch / "cmp"
+    sub.mkdir(parents=True, exist_ok=True)
+    env = dict(os.environ, WT_DATA_FILE=str(sub / "unused.json"))
+    run = real_subprocess.run(
+        [sys.executable, str(REPO / "tools" / "compare_close_task.py"),
+         str(old), str(migrated), str(sub)],
+        capture_output=True, text=True, env=env)
+    print("\n".join("    " + l for l in run.stdout.strip().splitlines()))
+    if run.stderr.strip():
+        print("    stderr:", run.stderr.strip()[:400])
+    same = len([l for l in run.stdout.splitlines() if l.startswith("  same ")])
+    diff = len([l for l in run.stdout.splitlines() if l.startswith("  DIFF ")])
+    err = len([l for l in run.stdout.splitlines() if l.startswith("  ERR ")])
+    check(err == 0, "no task errored under either version", f"{err} error(s)")
+    check(same >= 10, "at least 10 of 12 tasks have a byte-identical write sequence",
+          f"same={same} diff={diff}")
+    # The two known diffs are extra writes of the *same* values — never a
+    # different value — plus one Sprint field that used to be left unset.
+    changed_values = [l for l in run.stdout.splitlines()
+                      if l.strip().startswith("-") and "---" not in l]
+    check(not changed_values,
+          "no GitHub write was REMOVED or had its value changed "
+          "(diffs are additions only)", "\n      ".join(changed_values))
+
+
+def test_reconcile_harness_still_passes(fixture, migrated, baseline, scratch):
+    section("13. tools/test_reconcile.py (Phase 2) still passes")
+    sub = scratch / "phase2"
+    sub.mkdir(parents=True, exist_ok=True)
+    env = dict(os.environ, WT_DATA_FILE=str(sub / "unused.json"))
+    proc = real_subprocess.run(
+        [sys.executable, str(REPO / "tools" / "test_reconcile.py"),
+         str(fixture), str(migrated), str(baseline), str(sub)],
+        capture_output=True, text=True, env=env)
+    tail = proc.stdout.strip().splitlines()[-3:]
+    print("\n".join("    " + l for l in tail))
+    check(proc.returncode == 0, "test_reconcile.py exits 0", f"rc={proc.returncode}")
+
+
+def main():
+    if len(sys.argv) != 5:
+        print(__doc__.strip(), file=sys.stderr)
+        return 2
+    fixture, migrated, baseline, scratch = (Path(a).expanduser() for a in sys.argv[1:])
+    scratch.mkdir(parents=True, exist_ok=True)
+
+    os.environ.setdefault("WT_DATA_FILE", str(scratch / "unused.json"))
+    import wt
+
+    real = Path.home() / ".workload_tracker.json"
+    if wt._resolve_data_file() == real or wt.DATA_FILE == real:
+        print("REFUSING TO RUN: WT_DATA_FILE resolves to the live data file",
+              file=sys.stderr)
+        return 2
+
+    test_cli_smoke(wt, migrated, scratch)
+    test_sprint_offline(wt, migrated, scratch)
+    test_all_creates_nothing(wt, migrated, scratch)
+    test_recurrent_skipped(wt, migrated, scratch)
+    test_split_sprint_alias(wt, migrated, scratch)
+    work = test_idempotent(wt, migrated, scratch)
+    test_set_sprint(wt, migrated, scratch)
+    test_done(wt, migrated, scratch)
+    test_issue_routing(wt, migrated, scratch)
+    test_shadow_plumbing_gone(wt, migrated, scratch)
+    test_invariants(wt, work, baseline)
+    test_creation_paths(wt, migrated, scratch)
+    test_close_task_github_diff(migrated, scratch)
+    test_reconcile_harness_still_passes(fixture, migrated, baseline, scratch)
+
+    print(f"\n{CHECKS - len(FAILURES)}/{CHECKS} checks passed")
+    if FAILURES:
+        print(f"\n{len(FAILURES)} FAILURE(S):")
+        for f in FAILURES:
+            print(f"  x {f}")
+        return 1
+    print("All Phase 3 checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_reconcile.py
+++ b/tools/test_reconcile.py
@@ -1,0 +1,704 @@
+#!/usr/bin/env python3
+"""Verification harness for reconcile_task_sprints() (plan §2.3 / Phase 2).
+
+There is no automated test suite in this repo, so this script *is* the test for
+Phase 2. It runs fully offline: **every** function that shells out to `gh` is
+monkeypatched, and ``wt.subprocess`` itself is replaced with a guard that raises
+on any use, so a missed stub fails loudly instead of touching real GitHub.
+
+Usage:
+
+    WT_DATA_FILE=/tmp/ignored \\
+    venv/bin/python tools/test_reconcile.py <fixture.json> <migrated.json> \\
+                                            <baseline.pristine.json> <scratch-dir>
+
+  fixture.json    pre-migration copy of the data file
+  migrated.json   already-migrated copy (Phase 1 applied)
+  baseline        Phase-0 baseline for tools/check_invariants.py
+  scratch-dir     writable directory for working copies
+
+Exit status 0 when every check passes.
+"""
+import copy
+import json
+import os
+import shutil
+import subprocess as real_subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+FAILURES = []
+CHECKS = 0
+
+
+def check(ok, label, detail=""):
+    global CHECKS
+    CHECKS += 1
+    if ok:
+        print(f"  ok   {label}")
+    else:
+        print(f"  FAIL {label}  {detail}")
+        FAILURES.append(f"{label}  {detail}")
+    return ok
+
+
+def section(title):
+    print(f"\n=== {title} ===")
+
+
+# ---------------------------------------------------------------- gh stubbing --
+
+GH_FUNCS = [
+    "create_github_issue", "add_issue_to_project", "sync_project_status",
+    "update_project_hours", "update_project_sprint", "update_project_activity",
+    "update_project_type", "add_issue_comment", "close_github_issue",
+    "delete_github_issue", "ensure_issue_assigned", "issue_has_comments",
+    "update_issue_title", "get_project_info", "get_project_hours",
+    "get_all_sprints", "add_to_project_and_update", "add_issue_to_project",
+]
+
+
+class SubprocessGuard:
+    """Stand-in for wt.subprocess: any use is a bug in the test setup."""
+
+    def __getattr__(self, name):
+        def boom(*a, **k):
+            raise AssertionError(
+                f"wt.subprocess.{name} called with {a!r} — a gh stub is missing"
+            )
+        return boom
+
+
+class Stubs:
+    """Monkeypatch every gh-touching entry point in wt.
+
+    mode="strict": any call is a hard failure (used to prove dry-run purity).
+    mode="record": calls are recorded and plausible values returned.
+    """
+
+    def __init__(self, wt, mode="record", fail_on_create=None, sprints=None):
+        self.wt = wt
+        self.mode = mode
+        self.fail_on_create = fail_on_create or set()
+        self.sprints = sprints or []
+        self.calls = []
+        self._saved = {}
+        self._issue_no = 900000
+
+    def __enter__(self):
+        wt = self.wt
+        self._saved["subprocess"] = wt.subprocess
+        wt.subprocess = SubprocessGuard()
+        for name in set(GH_FUNCS):
+            self._saved[name] = getattr(wt, name)
+            setattr(wt, name, self._make(name))
+        return self
+
+    def __exit__(self, *exc):
+        for name, val in self._saved.items():
+            setattr(self.wt, name, val)
+        return False
+
+    def _make(self, name):
+        def stub(*args, **kwargs):
+            self.calls.append((name, args, kwargs))
+            if self.mode == "strict":
+                raise AssertionError(f"GitHub call {name}() during a dry run")
+            if name == "create_github_issue":
+                task, repo = args[0], args[1]
+                title = task.get("title", "")
+                for needle in self.fail_on_create:
+                    if needle in title:
+                        raise Exception(f"simulated gh failure for {title!r}")
+                self._issue_no += 1
+                return f"{repo}#{self._issue_no}"
+            if name == "add_issue_to_project":
+                return "PVTI_stub"
+            if name == "get_project_info":
+                return {
+                    "project_id": "PVT_stub",
+                    "status_field": {"id": "PVTF_status"},
+                    "hours_field": {"id": "PVTF_hours"},
+                    "status_options": {"Todo": "a", "In Progress": "b", "Done": "c"},
+                    "activity_options": {},
+                    "type_options": {},
+                }
+            if name == "get_all_sprints":
+                return copy.deepcopy(self.sprints)
+            if name == "get_project_hours":
+                return None
+            if name == "issue_has_comments":
+                return True
+            if name == "add_to_project_and_update":
+                return {"success": True}
+            return True
+        return stub
+
+    def names(self):
+        return [c[0] for c in self.calls]
+
+    def count(self, name):
+        return sum(1 for c in self.calls if c[0] == name)
+
+
+# ------------------------------------------------------------------- fixtures --
+
+def load_copy(wt, src, dst):
+    """Copy *src* to *dst*, point wt at it and wt.load() it.
+
+    wt resolves DATA_FILE once at import time, so the module constant has to be
+    rebound (not just the env var). Refuses anything that isn't a fresh copy in
+    the scratch dir, so no test can reach the live data file.
+    """
+    dst = Path(dst)
+    assert dst.name.endswith(".json") and dst != Path.home() / ".workload_tracker.json"
+    shutil.copyfile(src, dst)
+    os.environ["WT_DATA_FILE"] = str(dst)
+    wt.DATA_FILE = dst
+    return wt.load()
+
+
+def find(data, title):
+    for t in data["tasks"]:
+        if t["title"] == title:
+            return t
+    raise SystemExit(f"task not found: {title!r}")
+
+
+def sig(data):
+    return json.dumps(data, sort_keys=True, default=str)
+
+
+def brief(res):
+    out = []
+    for op in res["planned"]:
+        bits = [op["op"], str(op.get("sprint"))]
+        if op["op"] == "create":
+            bits.append(f"issue={op['issue_title']!r}" if op["create_issue"]
+                        else f"no-issue({op.get('skipped_github')})")
+            bits.append(f"{op['minutes']:.0f}m -> {op['hours']}h")
+        elif op["op"] == "repoint":
+            bits.append(f"{op.get('from_sprint')} -> {op['sprint']} ({op['issue']})")
+        elif op["op"] == "hours":
+            bits.append(f"{op['issue']} {op.get('from_hours')} -> {op['hours']}h")
+        elif op["op"] == "close":
+            bits.append(str(op.get("issue")))
+        elif op["op"] == "relabel":
+            bits.append(f"{op.get('from_sprint')} -> {op['sprint']}")
+        out.append("      " + "  ".join(bits))
+    return "\n".join(out) or "      (empty plan)"
+
+
+# ----------------------------------------------------------------------- tests --
+
+def test_dry_run_purity(wt, migrated, scratch):
+    section("1. dry-run purity over every task (strict stubs)")
+    data = load_copy(wt, migrated, scratch / "dry.json")
+    sprints = wt.get_cached_sprints(data)
+    before = sig(data)
+    disk_before = (scratch / "dry.json").read_text()
+
+    def no_save(_d):
+        raise AssertionError("save_callback called during a dry run")
+
+    planned = 0
+    with Stubs(wt, mode="strict", sprints=sprints) as st:
+        for task in data["tasks"]:
+            res = wt.reconcile_task_sprints(
+                task, data, sprints, dry_run=True, save_callback=no_save,
+            )
+            planned += len(res["planned"])
+            assert res["dry_run"] is True
+        check(st.calls == [], "zero GitHub calls", f"got {st.names()[:5]}")
+    check(sig(data) == before, "in-memory data unchanged")
+    check((scratch / "dry.json").read_text() == disk_before, "data file unchanged")
+    print(f"       ({planned} ops planned across {len(data['tasks'])} tasks)")
+
+
+def test_historical(wt, migrated, scratch):
+    section("2. historical multi-sprint tasks — plan only, nothing executed")
+    data = load_copy(wt, migrated, scratch / "hist.json")
+    sprints = wt.get_cached_sprints(data)
+    before = sig(data)
+    results = {}
+    with Stubs(wt, mode="strict", sprints=sprints) as st:
+        for title in ("Assist on Banco Galicia",
+                      "casanabria - Brokkr support for GrafanaCon"):
+            task = find(data, title)
+            res = wt.reconcile_task_sprints(task, data, sprints, dry_run=True)
+            results[title] = res
+            print(f"    {title}  (status={task['status']}, "
+                  f"issue={task.get('github_issue')})")
+            print(f"      target: "
+                  + ", ".join(f"{t['sprint']}={t['minutes']:.0f}m/{t['hours']}h"
+                              for t in res["target"]))
+            print(brief(res))
+        check(st.calls == [], "no GitHub calls while planning")
+    check(sig(data) == before, "no mutation while planning")
+
+    bg = results["Assist on Banco Galicia"]
+    creates = [o for o in bg["planned"] if o["op"] == "create"]
+    repoints = [o for o in bg["planned"] if o["op"] == "repoint"]
+    check([o["sprint"] for o in creates] == ["Sprint 95"],
+          "Banco Galicia mints exactly one new issue, for Sprint 95",
+          f"got {[o['sprint'] for o in creates]}")
+    check(len(repoints) == 1 and repoints[0]["issue"] == "grafana/field-eng#5069"
+          and repoints[0]["sprint"] == "Sprint 96",
+          "Banco Galicia carries #5069 forward to Sprint 96 (Option A)",
+          f"got {repoints}")
+    check(creates and creates[0]["issue_title"].endswith("(Sprint 95)"),
+          "past-sprint issue keeps the ' (Sprint N)' title suffix")
+
+    bk = results["casanabria - Brokkr support for GrafanaCon"]
+    bkc = [o["sprint"] for o in bk["planned"] if o["op"] == "create"]
+    bkr = [o for o in bk["planned"] if o["op"] == "repoint"]
+    check(bkc == ["Sprint 97"], "Brokkr mints one new issue, for Sprint 97",
+          f"got {bkc}")
+    check(len(bkr) == 1 and bkr[0]["sprint"] == "Sprint 98",
+          "Brokkr carries #5263 forward to Sprint 98", f"got {bkr}")
+
+    # Blast radius of a blanket run, for the record (plan §5: opt-in backfill).
+    with Stubs(wt, mode="strict", sprints=sprints):
+        total_issues = 0
+        tasks_affected = 0
+        for task in data["tasks"]:
+            res = wt.reconcile_task_sprints(task, data, sprints, dry_run=True)
+            n = sum(1 for o in res["planned"] if o["op"] == "create" and o["create_issue"])
+            total_issues += n
+            if n:
+                tasks_affected += 1
+    print(f"    NOTE: a blanket reconcile of all {len(data['tasks'])} tasks would "
+          f"mint {total_issues} issues across {tasks_affected} tasks — NOT executed.")
+
+
+def test_already_split(wt, migrated, scratch):
+    section("3. already-split task (IRON Infusion) must mint nothing")
+    data = load_copy(wt, migrated, scratch / "iron.json")
+    sprints = wt.get_cached_sprints(data)
+    task = find(data, "IRON Infusion")
+    print(f"    bindings: " + ", ".join(
+        f"{b['sprint']}={b['issue']}({b['state']},{b['hours_synced']})"
+        for b in task["sprint_issues"]))
+    with Stubs(wt, mode="strict", sprints=sprints) as st:
+        res = wt.reconcile_task_sprints(task, data, sprints, dry_run=True)
+        check(st.calls == [], "no GitHub calls while planning")
+    print(brief(res))
+    creates = [o for o in res["planned"] if o["op"] == "create"]
+    repoints = [o for o in res["planned"] if o["op"] == "repoint"]
+    check(creates == [], "no new bindings/issues planned", f"got {creates}")
+    check(repoints == [], "no issue re-pointed", f"got {repoints}")
+    check([o for o in res["planned"] if o["op"] == "close"] == [],
+          "no issue closed (all five bindings are already closed)")
+    check({o["op"] for o in res["planned"]} <= {"hours"},
+          "the only remaining op kind is an hours re-sync",
+          f"got {[o['op'] for o in res['planned']]}")
+    hours = [o for o in res["planned"] if o["op"] == "hours"]
+    print(f"    hours ops: {[(o['sprint'], o.get('from_hours'), o['hours']) for o in hours]}")
+    check(all(o["hours"] == wt.mins_to_quarter_hours(
+                  wt.task_mins_for_sprint(task, o["sprint_id"], sprints))
+              for o in hours),
+          "planned hours equal the round-up-per-sprint value from the logs")
+
+
+def test_marker_logs(wt, migrated, scratch):
+    section("4. marker-log independence (plan §1.3)")
+    # The three 0-minute "Sprint rollover marker" logs in the live data. NOTE:
+    # the brief named 'Document current FE platform' as one of them; in this data
+    # its Sprint-104 presence is a real 0.13-minute Timer session log, not a
+    # marker, so it is exercised separately below.
+    for title in ("Implement Sigil instrumentation in /validate-demo-blocks-steps",
+                  "CI Check to read Demo Blocks content and verify if the change "
+                  "would break the demo block",
+                  "Move demo block scripts to the new field-eng-demo-blocks repo"):
+        data = load_copy(wt, migrated, scratch / "marker.json")
+        sprints = wt.get_cached_sprints(data)
+        task = find(data, title)
+        markers = [l for l in task["logs"]
+                   if l.get("minutes", 0) == 0
+                   and "rollover marker" in (l.get("note") or "")]
+        with Stubs(wt, mode="strict", sprints=sprints):
+            res_with = wt.reconcile_task_sprints(task, data, sprints, dry_run=True)
+        short = title[:38]
+        print(f"    {title[:60]}  status={task['status']}  markers={len(markers)}")
+        print(brief(res_with))
+        check(len(markers) == 1, f"{short}…: fixture really has a marker log")
+
+        cur = res_with["current_sprint"]
+        existing = {b.get("sprint") for b in task.get("sprint_issues") or []}
+        bound_after = existing | {o["sprint"] for o in res_with["planned"]
+                                  if o["op"] in ("create", "repoint")}
+        bound_after -= {o.get("from_sprint") for o in res_with["planned"]
+                        if o["op"] == "repoint"}
+        if task["status"] == "done":
+            check(cur not in bound_after,
+                  f"{short}…: a done task gets no current-sprint binding",
+                  f"bound={bound_after}")
+        else:
+            check(cur in bound_after,
+                  f"{short}…: open task ends up bound to the current sprint ({cur})",
+                  f"bound={bound_after}")
+        check(not any(o["op"] == "create" and o["sprint"] == "Sprint 104"
+                      for o in res_with["planned"]),
+              f"{short}…: no issue minted for the marker's sprint")
+
+        # Same plan with the marker log deleted.
+        task["logs"] = [l for l in task["logs"] if l not in markers]
+        with Stubs(wt, mode="strict", sprints=sprints):
+            res_without = wt.reconcile_task_sprints(task, data, sprints, dry_run=True)
+        check(res_with["planned"] == res_without["planned"],
+              f"{short}…: deleting the marker log does not change the plan",
+              f"\n      with:    {[o['op'] for o in res_with['planned']]}"
+              f"\n      without: {[o['op'] for o in res_without['planned']]}")
+
+    # The task the brief named. Its Sprint-104 bucket is a real 0.13m log, so
+    # round-up-per-sprint (deliberately preserved) mints a 0.25h issue for it.
+    data = load_copy(wt, migrated, scratch / "marker2.json")
+    sprints = wt.get_cached_sprints(data)
+    task = find(data, "Document current FE platform")
+    with Stubs(wt, mode="strict", sprints=sprints):
+        res = wt.reconcile_task_sprints(task, data, sprints, dry_run=True)
+    print("    Document current FE platform  status=%s" % task["status"])
+    print(brief(res))
+    s104_id = next(s["id"] for s in sprints if s["title"] == "Sprint 104")
+    s104 = wt.bucket_logs_by_sprint(task, sprints).get(s104_id, [])
+    check(len(s104) == 1 and s104[0].get("minutes", 0) > 0
+          and "marker" not in (s104[0].get("note") or ""),
+          "its Sprint-104 log is a real 0.13m Timer session, not a marker",
+          str(s104))
+    check(any(o["op"] == "create" and o["sprint"] == "Sprint 104"
+              and o["hours"] == 0.25 for o in res["planned"]),
+          "round-up-per-sprint (preserved by design) bills that 0.13m as 0.25h")
+    check(res["current_sprint"] in {o["sprint"] for o in res["planned"]
+                                    if o["op"] == "repoint"},
+          "its current issue is carried forward to the current sprint",
+          str(res["planned"]))
+
+
+def test_idempotency(wt, migrated, scratch, baseline):
+    section("5. full stubbed reconcile, then idempotency + invariants")
+    work = scratch / "full.json"
+    data = load_copy(wt, migrated, work)
+    sprints = wt.get_cached_sprints(data)
+    mins_before = sum(sum(l.get("minutes", 0) for l in t.get("logs", []))
+                      for t in data["tasks"])
+    logs_before = sum(len(t.get("logs", [])) for t in data["tasks"])
+    tasks_before = len(data["tasks"])
+
+    totals = {"created": 0, "repointed": 0, "hours_updated": 0, "closed": 0}
+    with Stubs(wt, mode="record", sprints=sprints) as st:
+        for task in list(data["tasks"]):
+            res = wt.reconcile_task_sprints(task, data, sprints,
+                                            save_callback=wt.save)
+            if not res["success"]:
+                check(False, f"run 1 failed for {task['title']!r}", str(res["errors"]))
+            for k in totals:
+                totals[k] += len(res[k])
+        run1_calls = len(st.calls)
+        issues_created = st.count("create_github_issue")
+        closed = st.count("close_github_issue")
+    print(f"    run 1: {totals}  ({run1_calls} stubbed gh calls, "
+          f"{issues_created} issues 'created', {closed} issues 'closed')")
+    wt.save(data)
+
+    check(len(data["tasks"]) == tasks_before, "no tasks added or removed")
+    check(sum(len(t.get("logs", [])) for t in data["tasks"]) == logs_before,
+          "log count unchanged")
+    check(abs(sum(sum(l.get("minutes", 0) for l in t.get("logs", []))
+                  for t in data["tasks"]) - mins_before) < 1e-9,
+          "total minutes unchanged")
+
+    # Second run: empty plans, zero calls, zero mutation.
+    before = sig(data)
+    with Stubs(wt, mode="strict", sprints=sprints) as st:
+        leftover = {}
+        for task in list(data["tasks"]):
+            res = wt.reconcile_task_sprints(task, data, sprints, dry_run=False,
+                                            save_callback=wt.save)
+            if res["planned"]:
+                leftover[task["title"]] = res["planned"]
+        check(st.calls == [], "run 2 makes zero GitHub calls", f"{st.names()[:6]}")
+    check(not leftover, "run 2 plans nothing for every task",
+          json.dumps({k: [o["op"] for o in v] for k, v in leftover.items()})[:400])
+    check(sig(data) == before, "run 2 mutates nothing")
+
+    # Every binding's hours_synced now matches the logs (plan §6 invariant 6).
+    bad = []
+    for t in data["tasks"]:
+        for b in t.get("sprint_issues") or []:
+            if not b.get("sprint_id") or not b.get("issue"):
+                continue
+            m = wt.task_mins_for_sprint(t, b["sprint_id"], sprints)
+            if m <= 0:
+                continue
+            if b.get("hours_synced") != wt.mins_to_quarter_hours(m):
+                bad.append((t["title"], b.get("sprint"), b.get("hours_synced"),
+                            wt.mins_to_quarter_hours(m)))
+    check(not bad, "every binding with time has hours_synced == round-up(logs)",
+          str(bad[:4]))
+
+    section("7. tools/check_invariants.py after the stubbed full reconcile")
+    proc = real_subprocess.run(
+        [sys.executable, str(REPO / "tools" / "check_invariants.py"),
+         str(work), str(baseline)],
+        capture_output=True, text=True)
+    print("\n".join("    " + l for l in proc.stdout.strip().splitlines()))
+    if proc.stderr.strip():
+        print("    stderr:", proc.stderr.strip()[:500])
+    check(proc.returncode == 0, "check_invariants exits 0",
+          f"rc={proc.returncode}")
+    check("3/binding-coverage" not in proc.stdout,
+          "no binding-coverage warnings left (28 before)")
+    return work
+
+
+def test_partial_failure(wt, migrated, scratch):
+    section("6. partial failure: one sprint's issue creation raises")
+    data = load_copy(wt, migrated, scratch / "partial.json")
+    sprints = wt.get_cached_sprints(data)
+    by_title = {s["title"]: s for s in sprints}
+
+    def mid(sprint):
+        d = sprint["start_date"]
+        return datetime(d.year, d.month, d.day, 12, 0).timestamp() + 86400
+
+    task = {
+        "id": wt.uid(),
+        "title": "Synthetic three-sprint task",
+        "description": "",
+        "role_id": "other",
+        "status": "done",
+        "github_repo": "grafana/field-eng",
+        "created_at": time.time(),
+        "sprint_issues": [],
+        "logs": [
+            {"id": wt.uid() + "a", "minutes": 60, "note": "s95",
+             "at": mid(by_title["Sprint 95"]), "started_at": mid(by_title["Sprint 95"])},
+            {"id": wt.uid() + "b", "minutes": 120, "note": "s96",
+             "at": mid(by_title["Sprint 96"]), "started_at": mid(by_title["Sprint 96"])},
+            {"id": wt.uid() + "c", "minutes": 30, "note": "s97",
+             "at": mid(by_title["Sprint 97"]), "started_at": mid(by_title["Sprint 97"])},
+        ],
+    }
+    data["tasks"].append(task)
+
+    with Stubs(wt, mode="record", sprints=sprints,
+               fail_on_create={"(Sprint 96)"}) as st:
+        res = wt.reconcile_task_sprints(task, data, sprints, save_callback=wt.save)
+    print(brief(res))
+    print(f"    created={[(c['sprint'], c['issue']) for c in res['created']]}")
+    print(f"    errors={[(e.get('sprint'), e['error']) for e in res['errors']]}")
+    check(res["success"] is False, "success is False")
+    check(len(res["errors"]) == 1 and res["errors"][0]["sprint"] == "Sprint 96",
+          "exactly one error, against Sprint 96",
+          str([(e.get("sprint"), e["op"], e["error"]) for e in res["errors"]]))
+    check(any(s.get("reason", "").startswith("aborted") and s.get("sprint") == "Sprint 96"
+              for s in res["skipped"]),
+          "the failed sprint's follow-up ops are reported as aborted, not errors")
+    got = sorted(c["sprint"] for c in res["created"])
+    check(got == ["Sprint 95", "Sprint 97"],
+          "Sprint 95 and Sprint 97 still succeeded", str(got))
+    bound = {b["sprint"]: b for b in task["sprint_issues"]}
+    check(set(bound) == {"Sprint 95", "Sprint 97"},
+          "no half-written binding for the failed sprint", str(sorted(bound)))
+    check(all(b["issue"] and b["state"] == "closed" and b["hours_synced"]
+              for b in bound.values()),
+          "surviving bindings are coherent (issue + closed + hours)",
+          str(bound))
+    on_disk = json.loads((scratch / "partial.json").read_text())
+    persisted = next(t for t in on_disk["tasks"] if t["id"] == task["id"])
+    check(len(persisted["sprint_issues"]) == 2,
+          "the successful bindings were persisted to disk",
+          str(persisted["sprint_issues"]))
+
+    # A retry closes the gap and nothing is duplicated.
+    with Stubs(wt, mode="record", sprints=sprints) as st:
+        res2 = wt.reconcile_task_sprints(task, data, sprints, save_callback=wt.save)
+    check(res2["success"] and [c["sprint"] for c in res2["created"]] == ["Sprint 96"],
+          "retry creates only the missing Sprint 96 binding",
+          str([c["sprint"] for c in res2["created"]]))
+    check(len(task["sprint_issues"]) == 3 and
+          len({b["sprint_id"] for b in task["sprint_issues"]}) == 3,
+          "three distinct bindings, no duplicates")
+
+
+def test_wrapper(wt, migrated, scratch):
+    section("8. split_cross_sprint_task() wrapper keeps its contract")
+    data = load_copy(wt, migrated, scratch / "wrap.json")
+    sprints = wt.get_cached_sprints(data)
+    task = find(data, "Assist on Banco Galicia")
+    with Stubs(wt, mode="record", sprints=sprints) as st:
+        res = wt.split_cross_sprint_task(task, data, wt.save, sprints)
+    check(set(res) == {"success", "sprint_tasks_created", "main_sprint", "error"},
+          "return keys unchanged", str(sorted(res)))
+    check(res["success"] is True, "success", str(res))
+    check(res["main_sprint"] == "Sprint 96", "main_sprint is the most recent sprint",
+          str(res["main_sprint"]))
+    check([e["sprint"] for e in res["sprint_tasks_created"]] == ["Sprint 95"],
+          "one previous sprint reported", str(res["sprint_tasks_created"]))
+    check(all("cross_sprint_parent" not in t for t in data["tasks"]),
+          "no shadow task objects created")
+    print(f"    sprint_tasks_created={res['sprint_tasks_created']}")
+
+    # Single-sprint gate preserved.
+    single = find(data, "Update SLO Workshop")
+    with Stubs(wt, mode="strict", sprints=sprints):
+        res2 = wt.split_cross_sprint_task(single, data, wt.save, sprints)
+    check(res2["error"] == "Task only has time in one sprint",
+          "single-sprint gate preserved", str(res2))
+
+    # Second call on the same task is a no-op on GitHub.
+    with Stubs(wt, mode="strict", sprints=sprints) as st:
+        res3 = wt.split_cross_sprint_task(task, data, wt.save, sprints)
+        check(st.calls == [], "re-split makes no GitHub calls", str(st.names()))
+    check(res3["success"] and all(e.get("skipped") for e in res3["sprint_tasks_created"]),
+          "re-split reports every previous sprint as already split",
+          str(res3["sprint_tasks_created"]))
+
+
+def test_close_task(wt, migrated, scratch):
+    section("11. close_task() still works end to end (reconcile via the wrapper)")
+    data = load_copy(wt, migrated, scratch / "close.json")
+    sprints = wt.get_cached_sprints(data)
+    task = find(data, "Document current FE platform")
+    issue = task["github_issue"]
+    with Stubs(wt, mode="record", sprints=sprints) as st:
+        res = wt.close_task(task, data, wt.save)
+    print(f"    result: success={res['success']} split_performed={res['split_performed']} "
+          f"issue_closed={res['issue_closed']} project_updated={res['project_updated']} "
+          f"error={res['error']}")
+    print(f"    split_result.sprint_tasks_created="
+          f"{[(e.get('sprint'), e.get('issue_ref'), e.get('skipped'))
+              for e in (res['split_result'] or {}).get('sprint_tasks_created', [])]}")
+    print(f"    bindings: {[(b['sprint'], b['issue'], b['state'], b['hours_synced'])
+                            for b in task['sprint_issues']]}")
+    check(res["success"] is True, "close_task succeeded", str(res))
+    check(res["split_performed"] is True, "the cross-sprint step ran")
+    check(task["status"] == "done", "task marked done")
+    check(all("cross_sprint_parent" not in t for t in data["tasks"]),
+          "no shadow task objects created")
+    check(len(data["tasks"]) == 80, "no tasks added", str(len(data["tasks"])))
+    bound = {b["sprint"]: b for b in task["sprint_issues"]}
+    check(set(bound) == {"Sprint 97", "Sprint 98", "Sprint 104", "Sprint 105"},
+          "a binding per sprint with time, plus the current sprint", str(sorted(bound)))
+    check(bound["Sprint 105"]["issue"] == issue,
+          "the original issue is the current-sprint one (Option A)",
+          str(bound["Sprint 105"]))
+    check(st.count("create_github_issue") == 2,
+          "two past-sprint issues minted (Sprint 98 and Sprint 104)",
+          str(st.count("create_github_issue")))
+    check(all(b["state"] == "closed" for k, b in bound.items() if k != "Sprint 105"),
+          "past bindings closed", str(bound))
+    # Hours reported on the main issue must be the sprint-filtered value.
+    hour_calls = [c for c in st.calls if c[0] == "update_project_hours"]
+    print(f"    update_project_hours calls: "
+          f"{[(c[1][0], c[1][1]) for c in hour_calls]}")
+    main_hours = [c[1][1] for c in hour_calls if c[1][0] == issue]
+    expected = wt.mins_to_quarter_hours(
+        wt.task_mins_for_sprint(task, bound["Sprint 105"]["sprint_id"], sprints))
+    check(all(h == expected for h in main_hours),
+          f"main issue only ever told its current-sprint hours ({expected})",
+          str(main_hours))
+    check(bound["Sprint 105"]["state"] == "closed"
+          and bound["Sprint 105"]["hours_synced"] == expected,
+          "the current binding's cached state/hours match what close_task did",
+          str(bound["Sprint 105"]))
+    # A reconcile straight after must not try to re-close or re-push anything.
+    with Stubs(wt, mode="strict", sprints=sprints) as st:
+        after = wt.reconcile_task_sprints(task, data, sprints, save_callback=wt.save)
+        check(st.calls == [], "reconcile after close_task makes no GitHub calls",
+              str(st.names()))
+    check(after["planned"] == [], "reconcile after close_task plans nothing",
+          str([o["op"] for o in after["planned"]]))
+
+
+def test_set_sprint_drift(wt, migrated, scratch):
+    section("10. sprint_id ahead of the bindings (wt set-sprint) mints no duplicate")
+    data = load_copy(wt, migrated, scratch / "drift.json")
+    sprints = wt.get_cached_sprints(data)
+    task = find(data, "Update brokkr to use github app at run time")
+    issue = task["github_issue"]
+    current = wt.find_sprint_for_date(sprints, datetime.now().date())
+    # Simulate `wt set-sprint <task> "Sprint 105"`: sprint_id jumps forward, the
+    # binding stays behind on Sprint 101 with the live issue.
+    task["sprint_id"] = current["id"]
+    task["sprint"] = current["title"]
+    with Stubs(wt, mode="strict", sprints=sprints):
+        res = wt.reconcile_task_sprints(task, data, sprints, dry_run=True)
+    print(f"    bindings: {[(b['sprint'], b['issue'], b['state']) for b in task['sprint_issues']]}")
+    print(brief(res))
+    creates = [o for o in res["planned"] if o["op"] == "create"]
+    repoints = [o for o in res["planned"] if o["op"] == "repoint"]
+    check(not any(o["sprint"] == current["title"] for o in creates),
+          "no duplicate issue minted for the current sprint", str(creates))
+    check(len(repoints) == 1 and repoints[0]["issue"] == issue
+          and repoints[0]["sprint"] == current["title"],
+          "the live issue is carried forward instead", str(repoints))
+    check(not any(o["op"] == "close" and o["issue"] == issue
+                  for o in res["planned"]),
+          "the live issue is not closed out from under the open task")
+    check([o["sprint"] for o in creates] == ["Sprint 101"],
+          "the sprint it vacated (65m of real work) gets its own past-sprint issue",
+          str([o["sprint"] for o in creates]))
+
+
+def test_pre_migration(wt, fixture, scratch):
+    section("9. reconcile on a pre-migration fixture (load() migrates first)")
+    data = load_copy(wt, fixture, scratch / "pre.json")
+    check(len(data["tasks"]) == 80 and not any(t.get("cross_sprint_parent")
+                                              for t in data["tasks"]),
+          "load() migrated 92 -> 80 tasks, 0 shadows",
+          f"{len(data['tasks'])} tasks")
+    sprints = wt.get_cached_sprints(data)
+    task = find(data, "IRON Infusion")
+    with Stubs(wt, mode="strict", sprints=sprints):
+        res = wt.reconcile_task_sprints(task, data, sprints, dry_run=True)
+    check([o for o in res["planned"] if o["op"] in ("create", "repoint")] == [],
+          "IRON Infusion still mints nothing straight off the pristine fixture",
+          str(res["planned"]))
+
+
+def main():
+    if len(sys.argv) != 5:
+        print(__doc__.strip(), file=sys.stderr)
+        return 2
+    fixture, migrated, baseline, scratch = (Path(a).expanduser() for a in sys.argv[1:])
+    scratch.mkdir(parents=True, exist_ok=True)
+
+    # Point WT_DATA_FILE somewhere harmless before importing wt.
+    os.environ.setdefault("WT_DATA_FILE", str(scratch / "unused.json"))
+    import wt
+
+    real = Path.home() / ".workload_tracker.json"
+    if wt._resolve_data_file() == real or wt.DATA_FILE == real:
+        print("REFUSING TO RUN: WT_DATA_FILE resolves to the live data file",
+              file=sys.stderr)
+        return 2
+
+    test_dry_run_purity(wt, migrated, scratch)
+    test_historical(wt, migrated, scratch)
+    test_already_split(wt, migrated, scratch)
+    test_marker_logs(wt, migrated, scratch)
+    test_partial_failure(wt, migrated, scratch)
+    test_wrapper(wt, migrated, scratch)
+    test_close_task(wt, migrated, scratch)
+    test_set_sprint_drift(wt, migrated, scratch)
+    test_pre_migration(wt, fixture, scratch)
+    test_idempotency(wt, migrated, scratch, baseline)
+
+    print(f"\n{CHECKS - len(FAILURES)}/{CHECKS} checks passed")
+    if FAILURES:
+        print(f"\n{len(FAILURES)} FAILURE(S):")
+        for f in FAILURES:
+            print(f"  x {f}")
+        return 1
+    print("All reconcile checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_tracker_phase3.py
+++ b/tools/test_tracker_phase3.py
@@ -1,0 +1,668 @@
+#!/usr/bin/env python3
+"""Verification harness for Phase 3 of docs/plan-sprint-bindings.md — tracker.py.
+
+There is no automated test suite in this repo, so this script *is* the test for
+the TUI half of Phase 3. It runs fully offline and cannot touch anything real:
+
+  * ``HOME`` is redirected to a scratch directory holding a **copy** of the data
+    file, so ``Path.home() / ".workload_tracker.json"`` (which tracker.py
+    resolves at import time) can never be the live iCloud-synced file. The
+    script refuses to start if the resolved path is the real one.
+  * every ``gh``-touching function is stubbed in **both** ``wt`` and ``tracker``
+    (tracker binds them by value at import), ``wt.subprocess`` is swapped for a
+    guard that raises on any attribute access, and the real ``subprocess``
+    entry points plus ``os.system`` are replaced with raising stubs — so a
+    missed stub fails loudly instead of reaching GitHub.
+  * ``arc_browser`` / ``iterm_manager`` / ``browser_window`` are replaced with
+    fake modules and ``webbrowser.open`` is recorded, so no AppleScript,
+    Safari, Arc, iTerm or Hammerspoon call can escape.
+  * the HTTP bridge is never started (port 7373 stays free for the real TUI).
+
+The TUI itself is driven through Textual's official headless driver
+(``App.run_test()`` → ``Pilot``).
+
+Usage:
+
+    venv/bin/python test_tracker_phase3.py <fixture.json> <migrated.json> <scratch-dir>
+"""
+import asyncio
+import copy
+import json
+import os
+import re
+import shutil
+import sys
+import types
+from pathlib import Path
+
+REPO = Path("/Users/carlos/dev/carlos/workload-tracker/.claude/worktrees/sprint-bindings-plan")
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "tools"))
+
+FAILURES = []
+CHECKS = 0
+LIVE = Path.home() / ".workload_tracker.json"
+
+
+def check(ok, label, detail=""):
+    global CHECKS
+    CHECKS += 1
+    if ok:
+        print(f"  ok   {label}")
+    else:
+        print(f"  FAIL {label}  {detail}")
+        FAILURES.append(f"{label}  {detail}")
+    return ok
+
+
+def section(title):
+    print(f"\n=== {title} ===")
+
+
+# ─────────────────────────────────────────────────────── environment lockdown ──
+
+def build_home(scratch: Path, src: Path) -> Path:
+    """Fake $HOME containing a copy of *src* as ~/.workload_tracker.json."""
+    home = scratch / "home"
+    if home.exists():
+        shutil.rmtree(home)
+    (home / ".workload_tracker_notes").mkdir(parents=True)
+    dst = home / ".workload_tracker.json"
+    shutil.copyfile(src, dst)
+    os.environ["HOME"] = str(home)
+    os.environ["WT_DATA_FILE"] = str(dst)
+    return dst
+
+
+def fake_module(name, attrs=None):
+    mod = types.ModuleType(name)
+    for k, v in (attrs or {}).items():
+        setattr(mod, k, v)
+
+    def _boom(*a, **k):
+        raise AssertionError(f"{name} was actually used: {a!r} {k!r}")
+
+    class _Any:
+        def __init__(self, *a, **k):
+            raise AssertionError(f"{name}.<class> instantiated — automation leak")
+
+    mod.__getattr__ = lambda item: _Any  # type: ignore[attr-defined]
+    sys.modules[name] = mod
+    return mod
+
+
+def lock_down_subprocess():
+    """No process may be spawned from anywhere in this run."""
+    import subprocess
+
+    def boom(*a, **k):
+        raise AssertionError(f"subprocess call escaped the stubs: {a!r}")
+
+    for name in ("run", "Popen", "call", "check_call", "check_output"):
+        setattr(subprocess, name, boom)
+    os.system = boom  # type: ignore[assignment]
+
+
+# ───────────────────────────────────────────────────────────── main test body ──
+
+def main():
+    if len(sys.argv) != 4:
+        print(__doc__)
+        return 2
+    fixture, migrated, scratch = (Path(a) for a in sys.argv[1:4])
+    scratch.mkdir(parents=True, exist_ok=True)
+
+    data_file = build_home(scratch, migrated)
+    if data_file.resolve() == LIVE.resolve():
+        print("REFUSING TO RUN: resolved data file is the live one")
+        return 2
+    print(f"data file: {data_file}")
+    print(f"HOME:      {os.environ['HOME']}")
+
+    lock_down_subprocess()
+    fake_module("arc_browser")
+    fake_module("iterm_manager")
+    fake_module("browser_window")
+
+    import wt
+    from test_reconcile import Stubs, SubprocessGuard, GH_FUNCS  # noqa: F401
+
+    # wt resolves DATA_FILE at import; rebind so nothing can drift to $HOME.
+    wt.DATA_FILE = data_file
+    assert wt.DATA_FILE != LIVE
+
+    sprints = wt.get_cached_sprints(wt.load())
+    if not sprints:
+        print("fixture has no config.sprints_cache — cannot run offline")
+        return 2
+    print(f"offline sprints: {len(sprints)}")
+
+    import tracker
+    check(tracker.DATA_FILE == data_file,
+          "tracker.DATA_FILE points at the scratch copy", str(tracker.DATA_FILE))
+
+    # ---- stub every GitHub path, in wt *and* in tracker's own namespace -------
+    stubs = Stubs(wt, mode="record", sprints=sprints)
+    stubs.__enter__()
+    tracker_saved = {}
+    for name in set(GH_FUNCS):
+        if hasattr(wt, name) and hasattr(tracker, name):
+            # tracker bound these by value at import time, so it needs the stub too
+            tracker_saved[name] = getattr(tracker, name)
+            setattr(tracker, name, getattr(wt, name))
+    # setup_issue_in_project / sync_project_hours are real wt functions that call
+    # only stubbed primitives, so they can stay real — but tracker holds its own
+    # reference to the *original* objects, which is fine since those resolve wt
+    # globals at call time.
+    for name in ("setup_issue_in_project", "sync_project_hours"):
+        setattr(tracker, name, getattr(wt, name))
+    tracker.get_idle_seconds = lambda: 0.0
+    opened_urls = []
+    tracker.webbrowser = types.SimpleNamespace(open=lambda u: opened_urls.append(u))
+    # Never bind :7373 — the user may have the real TUI running.
+    tracker.WorkloadTracker._start_bridge_server = lambda self: None
+    check(True, "GitHub, subprocess, browser and automation calls are stubbed")
+
+    asyncio.run(run_tui_checks(tracker, wt, sprints, data_file, stubs, opened_urls))
+
+    static_checks()
+    migration_check(tracker, wt, fixture, scratch)
+
+    print()
+    if FAILURES:
+        print(f"{len(FAILURES)} of {CHECKS} checks FAILED:")
+        for f in FAILURES:
+            print(f"  - {f}")
+        return 1
+    print(f"{CHECKS}/{CHECKS} checks passed")
+    return 0
+
+
+def select(table, task_id) -> bool:
+    """Move a DataTable's cursor onto the row for *task_id*."""
+    for idx, key in enumerate(table.rows.keys()):
+        if key.value == task_id:
+            table.cursor_coordinate = (idx, 0)
+            return True
+    return False
+
+
+def find(data, title):
+    for t in data["tasks"]:
+        if t["title"] == title:
+            return t
+    raise SystemExit(f"task not found: {title!r}")
+
+
+async def run_tui_checks(tracker, wt, sprints, data_file, stubs, opened_urls):
+    app = tracker.WorkloadTracker()
+    data = app._data
+
+    # Record every notification: it is the TUI's only error channel, so a
+    # swallowed failure shows up here instead of vanishing.
+    notes = []
+    real_notify = app.notify
+
+    def notify(msg, **kw):
+        notes.append((kw.get("severity", "information"), str(msg)))
+        return real_notify(msg, **kw)
+
+    app.notify = notify
+
+    # Pick fixtures out of the real (copied) dataset. They must be tasks the
+    # board actually *shows* (not done, not recurrent), or a keypress would act
+    # on whatever row the cursor happens to sit on.
+    from datetime import datetime
+    current = wt.find_sprint_for_date(sprints, datetime.now().date())
+    idx = {s["id"]: i for i, s in enumerate(sprints)}
+    used = set()
+
+    def pick(pred):
+        for t in data["tasks"]:
+            if t.get("status") in ("done", "recurrent") or t["id"] in used:
+                continue
+            if pred(t):
+                used.add(t["id"])
+                return t
+        return None
+
+    def gap(t):
+        st = t.get("start_sprint_id")
+        if not st or st not in idx or not current:
+            return -1
+        return idx[current["id"]] - idx[st]
+
+    # Far-out-of-window start sprint → the old InvalidSelectValueError crash.
+    old_start = pick(lambda t: gap(t) > 4)
+    # A cross-sprint task with something for a reconcile to do.
+    multi = pick(lambda t: len(wt.task_sprints_with_time(t, sprints)) > 1)
+    # An in-progress cross-sprint task with an issue, for the close workflow. It
+    # may be one of the tasks above (the dataset only has a couple), just not the
+    # one the reconcile test already brought in sync.
+    close_target = next(
+        (t for t in data["tasks"]
+         if t.get("status") == "inprogress" and wt.task_current_issue(t, data)
+         and len(wt.task_sprints_with_time(t, sprints)) > 1
+         and t is not multi),
+        None)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        section("1. board render")
+        main_tbl = app.query_one("#task-table", tracker.DataTable)
+        rec_tbl = app.query_one("#task-table-recurrent", tracker.DataTable)
+        expected_main = [t for t in data["tasks"]
+                         if t.get("status") not in ("done", "recurrent")]
+        expected_rec = [t for t in data["tasks"] if t.get("status") == "recurrent"]
+        check(main_tbl.row_count == len(expected_main),
+              f"main table has {len(expected_main)} rows", str(main_tbl.row_count))
+        check(rec_tbl.row_count == len(expected_rec),
+              f"recurrent table has {len(expected_rec)} rows", str(rec_tbl.row_count))
+        check(all(t.get("cross_sprint_parent") is None for t in data["tasks"]),
+              "no shadow task survives load_data()")
+
+        section("2. sprint column reads the current binding")
+        rows = {k.value: main_tbl.get_row(k) for k in main_tbl.rows}
+        bad = []
+        for t in expected_main:
+            cell = rows[t["id"]][3]
+            b = wt.current_binding(t, data)
+            want = (b or {}).get("sprint") or t.get("sprint", "") or ""
+            if not cell.startswith(want):
+                bad.append((t["title"], cell, want))
+        check(not bad, "every Sprint cell starts with its current binding's sprint",
+              str(bad[:3]))
+        carry = [rows[t["id"]][3] for t in expected_main if "←" in rows[t["id"]][3]]
+        check(True, f"carry-over marker rendered on {len(carry)} row(s)",
+              f"e.g. {carry[0] if carry else 'none'}")
+
+        section("3. role filter + show-done keys")
+        roles = tracker.get_roles(data)
+        await pilot.press("1")
+        await pilot.pause()
+        want = len([t for t in expected_main if t.get("role_id") == roles[0]["id"]])
+        check(main_tbl.row_count == want,
+              f"'1' filters to role {roles[0]['id']} ({want} rows)", str(main_tbl.row_count))
+        await pilot.press("0")
+        await pilot.pause()
+        check(main_tbl.row_count == len(expected_main), "'0' restores all roles",
+              str(main_tbl.row_count))
+        await pilot.press("a")
+        await pilot.pause()
+        with_done = len([t for t in data["tasks"] if t.get("status") != "recurrent"])
+        check(main_tbl.row_count == with_done, f"'a' shows done tasks ({with_done} rows)",
+              str(main_tbl.row_count))
+        await pilot.press("a")
+        await pilot.pause()
+
+        section("4. edit modal on an out-of-window start sprint")
+        check(old_start is not None,
+              "found a visible task whose start_sprint is >4 sprints back",
+              old_start["title"] if old_start else "none")
+        check(select(main_tbl, old_start["id"]), f"selected '{old_start['title']}'")
+        main_tbl.focus()
+        await pilot.pause()
+        await pilot.press("e")
+        await pilot.pause()
+        modal = app.screen
+        check(isinstance(modal, tracker.TaskModal),
+              "TaskModal mounted without InvalidSelectValueError", type(modal).__name__)
+        sel = modal.query_one("#sel-sprint", tracker.Select)
+        check(sel.value == old_start["start_sprint_id"],
+              f"sprint Select shows the task's start sprint ({old_start.get('start_sprint')})",
+              str(sel.value))
+        before = copy.deepcopy(old_start)
+        modal.query_one("#btn-save", tracker.Button).press()
+        await pilot.pause()
+        await pilot.pause()
+        after = find(app._data, before["title"])
+        check(after.get("sprint_issues") == before.get("sprint_issues"),
+              "saving the edit modal preserves sprint_issues")
+        check(after.get("start_sprint_id") == before.get("start_sprint_id")
+              and after.get("start_sprint") == before.get("start_sprint"),
+              "saving the edit modal preserves start_sprint*")
+        check("cross_sprint_parent" not in after,
+              "saving the edit modal does not resurrect cross_sprint_parent")
+
+        section("5. log modal")
+        await pilot.press("l")
+        await pilot.pause()
+        check(isinstance(app.screen, tracker.EditLogsModal),
+              "EditLogsModal mounted", type(app.screen).__name__)
+        await pilot.press("escape")
+        await pilot.pause()
+
+        section("6. sync-sprints preview (dry run) is write-free")
+        before_bytes = data_file.read_bytes()
+        n_calls = len(stubs.calls)
+        check(multi is not None, "found a visible cross-sprint task",
+              multi["title"] if multi else "none")
+        check(select(main_tbl, multi["id"]), f"selected '{multi['title']}'")
+        main_tbl.focus()
+        await pilot.pause()
+        await pilot.press("S")
+        await pilot.pause()
+        check(isinstance(app.screen, tracker.SyncSprintsModal),
+              f"SyncSprintsModal mounted for '{multi['title']}'", type(app.screen).__name__)
+        plan_lines = getattr(app.screen, "_plan_lines", [])
+        check(bool(plan_lines), "preview lists a non-empty plan", str(plan_lines[:2]))
+        check(len(stubs.calls) == n_calls,
+              "the preview made zero GitHub calls",
+              str([c[0] for c in stubs.calls[n_calls:]]))
+        await pilot.press("escape")
+        await pilot.pause()
+        check(data_file.read_bytes() == before_bytes,
+              "cancelling the preview left the data file byte-identical")
+
+        section("7. sync-sprints skips recurrent tasks")
+        rec_task = [t for t in data["tasks"] if t.get("status") == "recurrent"][0]
+        select(rec_tbl, rec_task["id"]); rec_tbl.focus()
+        rec_tbl.focus()
+        await pilot.pause()
+        n_calls = len(stubs.calls)
+        await pilot.press("S")
+        await pilot.pause()
+        check(not isinstance(app.screen, tracker.SyncSprintsModal),
+              "no reconcile preview for a recurrent task", type(app.screen).__name__)
+        check(len(stubs.calls) == n_calls, "and no GitHub call was made")
+
+        section("8. sync-sprints execution reconciles per sprint")
+        select(main_tbl, multi["id"])
+        main_tbl.focus()
+        await pilot.pause()
+        before_bindings = {b.get("sprint_id") for b in multi.get("sprint_issues", [])}
+        before_dump = copy.deepcopy(multi.get("sprint_issues", []))
+        expected_sprints = {e["sprint_id"] for e in wt.task_sprints_with_time(multi, sprints)}
+        await pilot.press("S")
+        await pilot.pause()
+        check(isinstance(app.screen, tracker.SyncSprintsModal),
+              "preview re-opened for the execution pass", type(app.screen).__name__)
+        app.screen.dismiss(True)
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        after_bindings = {b.get("sprint_id") for b in multi.get("sprint_issues", [])}
+        check(expected_sprints <= after_bindings,
+              "every sprint with logged time now has a binding",
+              f"missing {sorted(expected_sprints - after_bindings)}")
+        check(len(multi["sprint_issues"]) >= len(before_dump),
+              "no binding was dropped",
+              f"before={[(b.get('sprint'), b.get('issue')) for b in before_dump]} "
+              f"after={[(b.get('sprint'), b.get('issue')) for b in multi['sprint_issues']]}")
+        # Option A carries the original issue *forward*, so an existing binding's
+        # sprint_id can move (a binding on a sprint with no minutes is re-pointed
+        # to the latest sprint). What must never happen is losing an issue ref.
+        before_issues = {b.get("issue") for b in before_dump if b.get("issue")}
+        after_issues = {b.get("issue") for b in multi["sprint_issues"] if b.get("issue")}
+        check(before_issues <= after_issues, "every issue ref survived the reconcile",
+              f"lost {sorted(before_issues - after_issues)}")
+        moved = before_bindings - after_bindings - {None}
+        check(all(wt.task_mins_for_sprint(multi, sid, sprints) == 0 for sid in moved),
+              "any re-pointed binding came off a sprint with no logged minutes",
+              f"moved {sorted(moved)}")
+        hours_by_sprint = {}
+        for b in multi["sprint_issues"]:
+            sid = b.get("sprint_id")
+            if b.get("hours_synced") is not None:
+                hours_by_sprint[sid] = b["hours_synced"]
+        wrong = {
+            sid: (h, wt.mins_to_quarter_hours(wt.task_mins_for_sprint(multi, sid, sprints)))
+            for sid, h in hours_by_sprint.items()
+            if abs(h - wt.mins_to_quarter_hours(
+                wt.task_mins_for_sprint(multi, sid, sprints))) > 1e-9
+        }
+        check(not wrong, "each binding's hours_synced == that sprint's own hours",
+              str(wrong))
+        total_hours = wt.mins_to_quarter_hours(wt.task_logged_mins(multi))
+        cur = wt.current_binding(multi, data)
+        check(cur is None or cur.get("hours_synced") is None
+              or len(expected_sprints) == 1
+              or abs(cur["hours_synced"] - total_hours) > 1e-9,
+              "the current issue was NOT told the whole task total",
+              f"{cur and cur.get('hours_synced')} vs total {total_hours}")
+        # second run is a no-op
+        n_calls = len(stubs.calls)
+        await pilot.press("S")
+        await pilot.pause()
+        check(not isinstance(app.screen, tracker.SyncSprintsModal),
+              "a second reconcile finds nothing to do (idempotent)",
+              type(app.screen).__name__)
+        check(len(stubs.calls) == n_calls, "and issues no GitHub call")
+
+        section("9. close workflow reports sprint-filtered hours")
+        check(close_target is not None,
+              "found an in-progress cross-sprint task with an issue",
+              close_target["title"] if close_target else "none")
+        # Re-resolve by id before every assertion: _on_task_saved() *replaces* the
+        # task dict when the edit modal is saved, so a reference captured earlier
+        # (section 4 edited this same task) points at an orphan.
+        target_id = close_target["id"]
+
+        def live():
+            return next(t for t in app._data["tasks"] if t["id"] == target_id)
+
+        target = live()
+        n_sprints_before = len(wt.task_sprints_with_time(target, sprints))
+        check(select(main_tbl, target_id), f"selected '{target['title']}'")
+        main_tbl.focus()
+        await pilot.pause()
+        task_total_hours = wt.mins_to_quarter_hours(wt.task_logged_mins(target))
+        n_calls = len(stubs.calls)
+        await pilot.press("D")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        check(isinstance(app.screen, tracker.ConfirmCloseTaskModal),
+              "ConfirmCloseTaskModal mounted", type(app.screen).__name__)
+        shown = app.screen._local_mins
+        check(abs(shown - wt.task_reportable_mins(live(), sprints)) < 1e-9,
+              "the modal shows the sprint-filtered minutes, not the task total",
+              f"{shown} vs reportable {wt.task_reportable_mins(live(), sprints)}")
+        app.screen.dismiss(True)
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        target = live()
+        print("    notifications:")
+        for sev, msg in notes[-14:]:
+            print(f"      [{sev}] {msg}")
+        check(target["status"] == "done", "task is marked done", target["status"])
+        # After the reconcile the current binding is the *latest* sprint, so the
+        # hours the close pushes are that sprint's own — which is the whole point
+        # of Option A. Compute the expectation the way close_task does.
+        cur_b = wt.current_binding(target, app._data)
+        expect_hours = wt.mins_to_quarter_hours(
+            wt.task_mins_for_sprint(target, (cur_b or {}).get("sprint_id"), sprints))
+        hours_pushed = [c[1][1] for c in stubs.calls[n_calls:]
+                        if c[0] == "add_to_project_and_update"]
+        check(hours_pushed and abs(hours_pushed[-1] - expect_hours) < 1e-9,
+              f"the current issue was told {expect_hours}h — only "
+              f"{(cur_b or {}).get('sprint')}'s own hours",
+              str(hours_pushed))
+        check(not any(abs(h - task_total_hours) < 1e-9 for h in hours_pushed)
+              or abs(expect_hours - task_total_hours) < 1e-9,
+              f"the task total ({task_total_hours}h) was never pushed as this "
+              f"issue's hours",
+              f"{hours_pushed} total={task_total_hours}")
+        closed = [c[1][0] for c in stubs.calls[n_calls:] if c[0] == "close_github_issue"]
+        check(bool(closed), "the GitHub issue was closed", str(closed))
+        bound = {b.get("sprint_id") for b in target.get("sprint_issues", [])}
+        want_bound = {e["sprint_id"] for e in wt.task_sprints_with_time(target, sprints)}
+        check(want_bound <= bound,
+              f"the close reconciled all {n_sprints_before} sprints with time first",
+              f"missing {sorted(want_bound - bound)}")
+        created = [c for c in stubs.calls[n_calls:] if c[0] == "create_github_issue"]
+        check(len(closed) >= 1 + len(created),
+              "each newly minted past-sprint issue was closed too",
+              f"{len(created)} created, {len(closed)} closed")
+
+        section("10. HTTP bridge helpers")
+        listed = app._bridge_list_tasks()["tasks"]
+        want = len([t for t in data["tasks"] if t.get("status") != "done"])
+        check(len(listed) == want, f"/tasks lists all {want} non-done tasks",
+              str(len(listed)))
+        status = app._bridge_status()
+        check("active_timer" in status and "time_by_role" in status,
+              "/status still renders")
+
+        section("11. open-issue action uses the accessor")
+        issued = next(t for t in data["tasks"] if wt.task_current_issue(t, data))
+        app.show_done = True
+        app._populate_table()
+        await pilot.pause()
+        select(main_tbl, issued["id"]); main_tbl.focus()
+        await pilot.pause()
+        await pilot.press("o")
+        await pilot.pause()
+        ref = wt.task_current_issue(issued, data)
+        repo, num = ref.rsplit("#", 1)
+        check(opened_urls and opened_urls[-1].endswith(f"{repo}/issues/{num}"),
+              "'o' opened the current binding's issue URL", str(opened_urls[-1:]))
+
+        # Snapshot for tools/check_invariants.py *before* the timer test appends a
+        # log (which would legitimately change the total minutes).
+        snapshot = data_file.parent.parent / "after_tui.json"
+        shutil.copyfile(data_file, snapshot)
+        print(f"    invariants snapshot: {snapshot}")
+
+        section("12. status / sync / update actions use the accessor")
+        app.show_done = False
+        app._populate_table()
+        await pilot.pause()
+        todo = next(t for t in app._data["tasks"]
+                    if t.get("status") == "todo" and wt.task_current_issue(t, app._data))
+        select(main_tbl, todo["id"])
+        main_tbl.focus()
+        await pilot.pause()
+        n_calls = len(stubs.calls)
+        await pilot.press("p")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        check(todo["status"] == "inprogress", "'p' moved the task to In Progress",
+              todo["status"])
+        synced = [c[1][0] for c in stubs.calls[n_calls:] if c[0] == "sync_project_status"]
+        check(synced and synced[0] == wt.task_current_issue(todo, app._data),
+              "'p' synced status on the current binding's issue", str(synced))
+        await pilot.press("g")
+        await pilot.pause()
+        check(isinstance(app.screen, tracker.SyncIssueModal),
+              "'g' on a linked task offers the project sync", type(app.screen).__name__)
+        check(app.screen._issue_ref == wt.task_current_issue(todo, app._data),
+              "and names the current binding's issue", str(app.screen._issue_ref))
+        await pilot.press("escape")
+        await pilot.pause()
+        n_calls = len(stubs.calls)
+        await pilot.press("u")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        check(any(c[0] == "add_issue_to_project" for c in stubs.calls[n_calls:]),
+              "'u' pushed the project fields", str([c[0] for c in stubs.calls[n_calls:]]))
+
+        section("13. timer start/stop syncs hours via the accessor")
+        # Arc tab cleanup would try to drive Arc through AppleScript on stop; the
+        # fake arc_browser module raises rather than silently no-op, so switch the
+        # feature off for this copy (the timer path is what's under test).
+        app._data.setdefault("config", {})["tab_cleanup_enabled"] = False
+        timed = next(t for t in app._data["tasks"]
+                     if t.get("status") == "inprogress" and not t.get("tabs")
+                     and wt.task_current_issue(t, app._data))
+        select(main_tbl, timed["id"])
+        main_tbl.focus()
+        await pilot.pause()
+        n_logs = len(timed.get("logs", []))
+        await pilot.press("t")
+        await pilot.pause()
+        check((app._data.get("active_timer") or {}).get("task_id") == timed["id"],
+              "'t' started the timer", str(app._data.get("active_timer")))
+        n_calls = len(stubs.calls)
+        await pilot.press("t")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        check(app._data.get("active_timer") is None, "'t' again stopped it")
+        check(len(timed.get("logs", [])) in (n_logs, n_logs + 1),
+              "a session log was appended (or the session was <0.1min)",
+              f"{n_logs} -> {len(timed.get('logs', []))}")
+        touched = [c for c in stubs.calls[n_calls:]
+                   if c[0] in ("update_project_hours", "sync_project_status")]
+        check(all(c[1][0] == wt.task_current_issue(timed, app._data) for c in touched),
+              "the hours sync targeted the current binding's issue",
+              str([(c[0], c[1][0]) for c in touched]))
+
+
+def static_checks():
+    section("14. static assertions on tracker.py")
+    src = (REPO / "tracker.py").read_text()
+    code_lines = []
+    for line in src.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        code_lines.append(line.split("#")[0])
+    code = "\n".join(code_lines)
+    check("cross_sprint_parent" not in code,
+          "no cross_sprint_parent reference survives in code",
+          [l for l in code.splitlines() if "cross_sprint_parent" in l][:2])
+
+    # every github_issue mention must be an import, a _create_github_issue flag,
+    # a method name, or the preserve-key list — never a task field read.
+    offenders = []
+    for m in re.finditer(r'.*github_issue.*', code):
+        line = m.group(0)
+        if re.search(r'(get|create|delete|update)_github_issue|_create_github_issue'
+                     r'|"github_issue", "sprint_issues"', line):
+            continue
+        offenders.append(line.strip())
+    check(not offenders, "no direct task['github_issue'] read/write remains",
+          str(offenders[:3]))
+    # The legacy sprint/sprint_id keys are still *written* (wt.py mirrors them and
+    # mcp_server.py + an older wt.py on the other Mac still read them), so a
+    # handful of reads remain by design. Pin the count so a new one is visible.
+    legacy = [l.strip() for l in code.splitlines()
+              if re.search(r'\.get\("sprint_id"\)|\["sprint_id"\]', l)]
+    check(len(legacy) == 6,
+          "exactly 6 legacy sprint_id sites remain (documented fallbacks + the "
+          "new-task legacy mirror)",
+          "\n        " + "\n        ".join(legacy))
+    check("split_cross_sprint_task" not in code and "sprint_summary_for_task" not in code,
+          "the deprecated split shims are no longer imported")
+
+
+def migration_check(tracker, wt, fixture, scratch):
+    section("15. load_data() migrates shadows (pre-migration fixture)")
+    home2 = scratch / "home_fixture"
+    if home2.exists():
+        shutil.rmtree(home2)
+    home2.mkdir(parents=True)
+    dst = home2 / ".workload_tracker.json"
+    shutil.copyfile(fixture, dst)
+    raw = json.loads(dst.read_text())
+    n_shadow = len([t for t in raw["tasks"] if t.get("cross_sprint_parent")])
+    check(n_shadow > 0, f"fixture really has {n_shadow} shadow task(s)")
+    saved = tracker.DATA_FILE
+    try:
+        tracker.DATA_FILE = dst
+        loaded = tracker.load_data()
+    finally:
+        tracker.DATA_FILE = saved
+    left = [t for t in loaded["tasks"] if t.get("cross_sprint_parent")]
+    check(not left, "load_data() converted every shadow into bindings", str(len(left)))
+    check(len(loaded["tasks"]) == len(raw["tasks"]) - n_shadow,
+          f"task count dropped by {n_shadow}",
+          f"{len(raw['tasks'])} -> {len(loaded['tasks'])}")
+    on_disk = json.loads(dst.read_text())
+    check(not [t for t in on_disk["tasks"] if t.get("cross_sprint_parent")],
+          "and persisted the migration to disk")
+    before_mins = sum(sum(l.get("minutes", 0) for l in t.get("logs", []))
+                      for t in raw["tasks"] if not t.get("cross_sprint_parent"))
+    after_mins = sum(sum(l.get("minutes", 0) for l in t.get("logs", []))
+                     for t in loaded["tasks"])
+    check(abs(before_mins - after_mins) < 1e-9,
+          "non-shadow log minutes unchanged by the migration",
+          f"{before_mins} vs {after_mins}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tracker.py
+++ b/tracker.py
@@ -9,11 +9,14 @@ Keyboard shortcuts:
   d        — Delete selected task
   t        — Toggle timer on selected task
   l        — Manage time logs (add/edit/delete/split/merge)
-  s        — Cycle status of selected task
+  p        — Move a To Do task to In Progress
+  D        — Close the task (GitHub close workflow)
+  S        — Sync the task's per-sprint GitHub issues with its logs
   g        — Create and link GitHub issue
   o        — Open linked GitHub issue in browser
   c        — Import from Google Calendar
   a        — Toggle showing done tasks
+  r        — Reload the data file from disk
   1-4      — Filter by role (1=DemoKit, 2=Demos, 3=Strategic, 4=Other, 0=All)
   tab      — Switch between Task board / Overview panels
   ↑↓       — Navigate tasks
@@ -23,6 +26,11 @@ Notes column indicators:
   C        — Imported from calendar
   #        — Linked to GitHub issue
   +        — Has local notes
+
+Sprint column: the sprint whose GitHub issue the task's hours currently go to.
+"Sprint 105 ← Sprint 103" means the work started in Sprint 103 and carried over;
+Sprint 103's hours live on their own (closed) issue. See `S` above and
+docs/plan-sprint-bindings.md.
 """
 
 import json
@@ -45,22 +53,41 @@ from textual.widgets import (
     Select, Static, Switch, TabbedContent, TabPane, TextArea
 )
 from textual.reactive import reactive
+from rich.markup import escape as _escape_markup
 
 from idle_detector import get_idle_seconds
 from wt import (
     load as wt_load, save as wt_save, resolve_task,
-    get_task_repo, create_github_issue, add_to_project_and_update, close_github_issue, delete_github_issue,
-    sync_project_status, get_task_activity, get_task_type, update_project_activity, update_project_type,
+    get_task_repo, create_github_issue, delete_github_issue,
+    sync_project_status, get_task_activity,
     get_calendar_events,
     get_gcal_service, GCAL_CREDENTIALS_FILE, setup_issue_in_project, sync_project_hours,
     task_logged_mins as wt_task_logged_mins, task_uploaded_mins, task_pending_upload_mins,
-    get_project_hours, mins_to_quarter_hours, fmt_mins as wt_fmt_mins, get_current_sprint,
-    get_imported_calendar_uids, find_calendar_event_owner, get_all_sprints, sprint_summary_for_task, split_cross_sprint_task,
+    get_project_hours, mins_to_quarter_hours, fmt_mins as wt_fmt_mins,
+    get_imported_calendar_uids, find_calendar_event_owner, get_all_sprints,
     get_event_mapping, set_event_mapping, remove_event_mapping, resolve_task_by_id,
     save_sprints_cache, get_sprint_date_range_for_task,
     resolve_event_to_task, strip_sprint_suffix,
     get_event_names_for_base, round_up_to_30,
     get_project_info, get_cached_project_options, _migrate_role_github_fields,
+    # ── Phase 3 of docs/plan-sprint-bindings.md ──────────────────────────────
+    # Per-sprint issue *bindings* (task["sprint_issues"]) replace the old shadow
+    # task objects, so: every read of task["github_issue"] goes through
+    # task_current_issue(); writes go through set_/clear_task_current_issue()
+    # (which still mirror the legacy flat key — mcp_server.py and an older wt.py
+    # on the other Mac read it); hours reported to GitHub come from
+    # task_reportable_mins() (the current binding's sprint, never the task
+    # total, which would double-count a carry-over); and the cross-sprint split
+    # is now the idempotent reconcile_task_sprints().
+    _migrate_shadows_to_bindings, task_current_issue, set_task_current_issue,
+    clear_task_current_issue, task_binding_for_sprint, task_start_sprint,
+    task_reportable_mins, task_sprints_with_time, reconcile_task_sprints,
+    close_task as wt_close_task, current_binding,
+    get_cached_sprints, find_sprint_for_date,
+    # Shared renderers for a reconcile plan / outcome so the TUI's wording
+    # matches `wt sync-sprints`. Underscore-prefixed but the supported way to
+    # describe a reconcile result (see wt.cmd_sync_sprints).
+    _reconcile_plan_lines, _reconcile_outcome_lines,
 )
 
 DATA_FILE = Path.home() / ".workload_tracker.json"
@@ -88,6 +115,17 @@ def uid() -> str:
     return datetime.now().strftime("%Y%m%d%H%M%S") + "".join(random.choices(string.ascii_lowercase, k=4))
 
 
+def esc(text) -> str:
+    """Escape Rich markup in *text*.
+
+    Labels and notifications render markup, so a task title like
+    ``[Oracle] False DB load needed`` (there is one in the live data) or an
+    issue title echoed back from a reconcile plan would otherwise be parsed as
+    a style tag.
+    """
+    return _escape_markup(str(text))
+
+
 def fmt_mins(mins: float) -> str:
     if not mins:
         return "0m"
@@ -110,7 +148,16 @@ def load_data() -> dict:
         data["roles"] = [r.copy() for r in DEFAULT_ROLES]
     # Move role github fields onto tasks (idempotent). Persist with a direct
     # write — save_data() would resurrect the stripped role fields from disk.
-    if _migrate_role_github_fields(data):
+    mutated = _migrate_role_github_fields(data)
+    # Convert cross-sprint shadow tasks into per-sprint issue bindings, and keep
+    # stripping shadows re-introduced by an older wt.py on the other Mac (via
+    # iCloud). Offline + idempotent. The TUI runs its own loader rather than
+    # wt.load(), so it has to run this itself — every cross_sprint_parent filter
+    # was removed from the board/bridge/edit modal on the strength of this
+    # guarantee, and without it a synced-in shadow would show up as a duplicate
+    # task and double-count in the overview totals.
+    mutated = _migrate_shadows_to_bindings(data) or mutated
+    if mutated:
         DATA_FILE.write_text(json.dumps(data, indent=2))
     return data
 
@@ -229,15 +276,29 @@ class TaskModal(ModalScreen):
         else:
             _recent = self._sprints[-5:]
 
-        # Ensure the task's existing sprint is selectable even if it falls outside
-        # the recent window (e.g. recurrent tasks pointing at an older sprint).
-        task_sprint_id = t.get("sprint_id")
+        # The sprint Select edits the task's **start** sprint (plan §2.1/§3):
+        # which sprint's issue carries which hours is derived from log timestamps
+        # and materialised as sprint_issues bindings by a reconcile, so it is not
+        # something you pick from a dropdown any more. start_sprint is only
+        # "when did this work begin" — frozen at migration from the earliest log,
+        # editable here (and via `wt set-sprint`) as a correction.
+        #
+        # Keep the out-of-window injection: start_sprint_id is frozen at the
+        # *earliest* log, so it is out of the "current + previous 4" window far
+        # more often than the old mutable sprint_id was (a task started in
+        # Sprint 95 with current = Sprint 105). Without this, Textual's strict
+        # Select raises InvalidSelectValueError on mount and the edit modal
+        # crashes — exactly the bug the original workaround fixed.
+        task_sprint_id = t.get("start_sprint_id") or t.get("sprint_id")
         if task_sprint_id and not any(s["id"] == task_sprint_id for s in _recent):
             existing = next((s for s in self._sprints if s["id"] == task_sprint_id), None)
             if existing is not None:
                 _recent = [existing] + list(_recent)
             else:
-                _recent = [{"id": task_sprint_id, "title": t.get("sprint") or task_sprint_id}] + list(_recent)
+                _recent = [{
+                    "id": task_sprint_id,
+                    "title": t.get("start_sprint") or t.get("sprint") or task_sprint_id,
+                }] + list(_recent)
 
         sprint_options = [("(none)", "")] + [(s["title"], s["id"]) for s in reversed(_recent)]
         default_sprint = task_sprint_id or ""
@@ -265,7 +326,8 @@ class TaskModal(ModalScreen):
             yield Input(value=t.get("description", ""), placeholder="Description (optional)", id="inp-desc")
             yield Select(role_options, value=t.get("role_id", default_role), id="sel-role", prompt="Select role")
             yield Select(status_options, value=t.get("status", "todo"), id="sel-status", prompt="Select status")
-            yield Select(sprint_options, value=default_sprint, id="sel-sprint", prompt="Select sprint")
+            yield Select(sprint_options, value=default_sprint, id="sel-sprint",
+                         prompt="Select start sprint")
             yield Input(value=t.get("local_folder", ""), placeholder="Local folder path (optional, e.g., ~/dev/myproject)", id="inp-local-folder")
             yield Input(value=t.get("github_repo", ""), placeholder="GitHub repo (owner/repo, optional)", id="inp-repo")
             yield Select(activity_options, value=default_activity, id="sel-activity", prompt="Select activity")
@@ -321,13 +383,13 @@ class TaskModal(ModalScreen):
                 result["local_folder"] = str(folder_path.resolve())
             else:
                 result["local_folder"] = local_folder  # Store as-is, will error on use
-        # Handle sprint selection
+        # Handle sprint selection — the *start* sprint (see compose()).
         sprint_id = self.query_one("#sel-sprint").value
         if sprint_id:
             sprint = next((s for s in self._sprints if s["id"] == sprint_id), None)
             if sprint:
-                result["sprint"] = sprint["title"]
-                result["sprint_id"] = sprint["id"]
+                result["start_sprint"] = sprint["title"]
+                result["start_sprint_id"] = sprint["id"]
         # GitHub fields (per task; empty widget value clears the field)
         github_repo = self.query_one("#inp-repo").value.strip()
         if github_repo:
@@ -338,9 +400,24 @@ class TaskModal(ModalScreen):
         type_val = self.query_one("#sel-type").value
         if type_val:
             result["type"] = type_val
-        # Preserve additional fields from existing task
+        # Preserve additional fields from the existing task. _save() rebuilds the
+        # task dict from scratch, so anything missing from this list is silently
+        # dropped on every edit — sprint_issues especially (losing it would
+        # orphan every past-sprint GitHub issue the task is billed to).
+        #
+        # cross_sprint_parent is gone: shadows no longer exist (load_data() runs
+        # the migration), so there is nothing to carry over.
+        #
+        # start_sprint/start_sprint_id are in the list even though the Select
+        # writes them: when self._sprints is empty (the TUI's fetch hasn't landed
+        # and there is no cached sprint list) the Select renders "(none)" and
+        # writes nothing, and preserving is far better than silently clearing.
+        # Clearing a start sprint is `wt set-sprint <task> none`.
         if self._task_data:
-            for key in ("github_issue", "arc_folder_id", "archived_tabs", "iterm_session_name", "task_folder_path", "calendar_event_uid", "sprint", "sprint_id", "tabs", "active_window_id", "cross_sprint_parent"):
+            for key in ("github_issue", "sprint_issues", "arc_folder_id", "archived_tabs",
+                        "iterm_session_name", "task_folder_path", "calendar_event_uid",
+                        "sprint", "sprint_id", "start_sprint", "start_sprint_id",
+                        "tabs", "active_window_id"):
                 if key in self._task_data and key not in result:
                     result[key] = self._task_data[key]
             # Track if title changed for GitHub issue update
@@ -692,19 +769,35 @@ class ConfirmCloseTaskModal(ModalScreen):
     .hours-row { margin-bottom: 1; }
     """
 
-    def __init__(self, task_title: str, local_mins: float, gh_hours: float | None):
+    def __init__(self, task_title: str, local_mins: float, gh_hours: float | None,
+                 sprint_title: str | None = None, total_mins: float | None = None,
+                 n_sprints: int = 0):
         super().__init__()
         self._task_title = task_title
+        # local_mins is the *reportable* total: the hours that will be pushed to
+        # this issue, i.e. only the current binding's sprint (plan §2.4 Option A).
         self._local_mins = local_mins
         self._gh_hours = gh_hours
+        self._sprint_title = sprint_title
+        self._total_mins = total_mins
+        self._n_sprints = n_sprints
 
     def compose(self) -> ComposeResult:
         local_hours = mins_to_quarter_hours(self._local_mins) if self._local_mins > 0 else 0
+        label = f"Local logged ({self._sprint_title})" if self._sprint_title else "Local logged"
         with Container(id="close-task-box"):
             yield Label("[bold]Close Task?[/]")
             yield Label(f"Task: '{self._task_title}'")
             yield Label("")
-            yield Label(f"[bold]Local logged:[/] {fmt_mins(self._local_mins)} → [green]{local_hours}h[/]", classes="hours-row")
+            yield Label(f"[bold]{label}:[/] {fmt_mins(self._local_mins)} → [green]{local_hours}h[/]", classes="hours-row")
+            if self._total_mins is not None and abs(self._total_mins - self._local_mins) > 1e-9:
+                # Earlier sprints' hours live on their own issues, so they are
+                # deliberately not part of what this close reports.
+                where = f"{self._n_sprints} sprints" if self._n_sprints else "all sprints"
+                yield Label(
+                    f"[dim]Task total across {where}: {fmt_mins(self._total_mins)}[/]",
+                    classes="hours-row",
+                )
             if self._gh_hours is not None:
                 yield Label(f"[bold]GitHub project:[/] [cyan]{self._gh_hours}h[/]", classes="hours-row")
                 if local_hours != self._gh_hours:
@@ -730,6 +823,84 @@ class ConfirmCloseTaskModal(ModalScreen):
         self.dismiss(True)
 
     @on(Button.Pressed, "#btn-cancel-close")
+    def cancel(self):
+        self.dismiss(False)
+
+
+# ──────────────────────────────────────────────────────────
+# Modal: Sync sprint bindings (reconcile preview)
+# ──────────────────────────────────────────────────────────
+
+class SyncSprintsModal(ModalScreen):
+    """Preview of a ``reconcile_task_sprints`` dry run, with a confirm button.
+
+    The TUI counterpart of ``wt sync-sprints <task> --dry-run`` followed by the
+    "Proceed? [Y/n]" prompt: the plan lines come from the same
+    ``wt._reconcile_plan_lines`` renderer the CLI uses, so both surfaces describe
+    a reconcile identically. Dismissing with True runs it for real.
+
+    Reconciling can *create* GitHub issues (one per past sprint that has hours but
+    no issue yet), which is irreversible, so the count is called out and the
+    Cancel button takes focus.
+    """
+    CSS = """
+    SyncSprintsModal { align: center middle; }
+    #sync-sprints-box {
+        width: 90;
+        height: auto;
+        max-height: 85%;
+        background: $surface;
+        border: tall $primary;
+        padding: 1 2;
+    }
+    #sync-sprints-box Label { margin-bottom: 1; }
+    #sync-sprints-plan { height: auto; max-height: 20; }
+    #sync-sprints-actions { margin-top: 1; }
+    """
+
+    def __init__(self, task_title: str, breakdown: str, plan_lines: list[str],
+                 n_new_issues: int = 0):
+        super().__init__()
+        self._task_title = task_title
+        self._breakdown = breakdown
+        self._plan_lines = plan_lines
+        self._n_new_issues = n_new_issues
+
+    def compose(self) -> ComposeResult:
+        with Container(id="sync-sprints-box"):
+            yield Label("[bold]Sync sprint bindings?[/]")
+            yield Label(f"Task: '{esc(self._task_title)}'")
+            if self._breakdown:
+                yield Label(f"[dim]Logs by sprint: {esc(self._breakdown)}[/]")
+            yield Label("")
+            with ScrollableContainer(id="sync-sprints-plan"):
+                for line in self._plan_lines:
+                    # Plan lines quote issue titles, i.e. task titles.
+                    yield Label(esc(line))
+            yield Label("")
+            if self._n_new_issues:
+                yield Label(
+                    f"[yellow]This creates {self._n_new_issues} new GitHub "
+                    f"issue(s) — not reversible.[/]"
+                )
+            with Horizontal(id="sync-sprints-actions"):
+                yield Button("Sync  [y]", variant="primary", id="btn-sync-sprints")
+                yield Button("Cancel  [esc]", id="btn-cancel-sync-sprints")
+
+    def on_mount(self):
+        self.query_one("#btn-cancel-sync-sprints").focus()
+
+    def on_key(self, event):
+        if event.key == "escape":
+            self.dismiss(False)
+        elif event.key == "y":
+            self.dismiss(True)
+
+    @on(Button.Pressed, "#btn-sync-sprints")
+    def confirm(self):
+        self.dismiss(True)
+
+    @on(Button.Pressed, "#btn-cancel-sync-sprints")
     def cancel(self):
         self.dismiss(False)
 
@@ -2857,6 +3028,7 @@ class WorkloadTracker(App):
         Binding("l",   "log_time",    "Manage logs"),
         Binding("p",   "start_progress", "Start"),
         Binding("D",   "mark_done",   "Done"),
+        Binding("S",   "sync_sprints", "Sync sprints"),
         Binding("g",   "link_github", "GitHub"),
         Binding("u",   "update_github", "Update GH"),
         Binding("o",   "open_github", "Open issue"),
@@ -2887,6 +3059,28 @@ class WorkloadTracker(App):
         self._sprints_cache: list[dict] = []
         self._sprints_fetched = False
         self._bridge_server: Optional[HTTPServer] = None
+
+    # ── Sprint context (offline) ───────────────────────────
+
+    def _sprints(self) -> list:
+        """Sprint list for UI code: live fetch if it has landed, else the cache.
+
+        ``_fetch_sprints_worker`` only fills ``_sprints_cache`` after a GitHub
+        round-trip, so until then the board, the edit modal's sprint Select and
+        the reconcile preview would see *no* sprints at all. Falling back to
+        ``config.sprints_cache`` makes all of them work from the first frame and
+        keeps every sprint lookup on the event loop offline. Both sources use the
+        same date-object contract (``start_date``/``end_date``).
+        """
+        return self._sprints_cache or get_cached_sprints(self._data)
+
+    def _current_sprint(self) -> Optional[dict]:
+        """Today's sprint, resolved offline. None when no sprint list is known.
+
+        Replaces ``wt.get_current_sprint()`` on the event loop, which fetches
+        from GitHub (a blocking ``gh`` call) on every keypress that needed it.
+        """
+        return find_sprint_for_date(self._sprints(), datetime.now().date())
 
     def _bg_start(self, label: str):
         """Show a background operation in the header subtitle."""
@@ -2968,7 +3162,15 @@ class WorkloadTracker(App):
 
     @work(thread=True)
     def _fetch_sprints_worker(self):
-        """Fetch sprints from GitHub and check for cross-sprint tasks."""
+        """Fetch sprints from GitHub and persist them for offline use.
+
+        Phase 3 dropped the "'<task>' has time in N sprints. Use 'wt
+        split-sprint' to split." notification this used to raise on mount (plan
+        §3): a task with hours in several sprints is now a normal, supported
+        state, and bringing its per-sprint issues in line is an idempotent
+        reconcile the user can run whenever (``S`` here, ``wt sync-sprints``
+        outside) rather than a ritual they have to be nagged about.
+        """
         self._bg_start("Fetching sprints")
         try:
             sprints = get_all_sprints(self._data)
@@ -2991,31 +3193,11 @@ class WorkloadTracker(App):
             if sprints or self._data.get("config", {}).get("project_options_cache"):
                 save_data(self._data)
 
-            # Auto-detect cross-sprint tasks
+            # The board's Sprint column and the edit modal both read the sprint
+            # list, so re-render once the live one lands (it may differ from the
+            # cache _sprints() served until now — e.g. a brand-new sprint).
             if sprints:
-                from datetime import datetime
-                current = None
-                today = datetime.now().date()
-                for s in sprints:
-                    if s["start_date"] <= today < s["end_date"]:
-                        current = s
-                        break
-
-                if current:
-                    for task in self._data.get("tasks", []):
-                        if task.get("status") in ("done", "recurrent") or task.get("cross_sprint_parent"):
-                            continue
-                        if not task.get("logs"):
-                            continue
-                        summary = sprint_summary_for_task(task, sprints)
-                        if len(summary) > 1:
-                            self.call_from_thread(
-                                self.notify,
-                                f"'{task['title']}' has time in {len(summary)} sprints. Use 'wt split-sprint' to split.",
-                                title="Cross-sprint detected",
-                                severity="warning",
-                                timeout=8,
-                            )
+                self.call_from_thread(self._populate_table)
         finally:
             self._bg_end("Fetching sprints")
 
@@ -3065,6 +3247,7 @@ class WorkloadTracker(App):
         role_map = get_role_map(self._data)
         roles = get_roles(self._data)
         default_role = roles[-1] if roles else {"id": "other", "label": "Other", "color": "white"}
+        sprints = self._sprints()
         for task in tasks:
             logged = task_logged_mins(task) + task_live_mins(task, self._data.get("active_timer"))
             role = role_map.get(task["role_id"], default_role)
@@ -3077,13 +3260,13 @@ class WorkloadTracker(App):
             # Notes indicator: # for GitHub issue, + for local notes, C for calendar
             if task.get("calendar_event_uid"):
                 notes_icon = "C"
-            elif task.get("github_issue"):
+            elif task_current_issue(task, self._data):
                 notes_icon = "#"
             elif has_local_notes(task["id"]):
                 notes_icon = "+"
             else:
                 notes_icon = " "
-            sprint_label = task.get("sprint", "")
+            sprint_label = self._sprint_cell(task, sprints)
             table.add_row(
                 timer_dot,
                 task["title"],
@@ -3106,6 +3289,26 @@ class WorkloadTracker(App):
             except Exception:
                 pass
 
+    def _sprint_cell(self, task: dict, sprints: list) -> str:
+        """The board's Sprint column for *task*.
+
+        Shows the sprint of the task's **current binding** — the sprint whose
+        GitHub issue the task's hours are currently reported to — falling back to
+        the legacy ``task["sprint"]`` for data that has no bindings. A carry-over
+        (work that began in a strictly earlier sprint) is marked ``← Sprint N``,
+        the board's equivalent of the "started Sprint N" note in ``wt sprint``.
+        """
+        binding = current_binding(task, self._data)
+        label = (binding or {}).get("sprint") or task.get("sprint", "") or ""
+        if not sprints:
+            return label
+        by_id = {s["id"]: s for s in sprints if s.get("id")}
+        shown = by_id.get((binding or {}).get("sprint_id") or task.get("sprint_id"))
+        start = task_start_sprint(task, sprints)
+        if start and shown and start["id"] != shown["id"] and start["start_date"] < shown["start_date"]:
+            return f"{label} ← {start['title']}"
+        return label
+
     def _populate_table(self):
         main_tasks, recurrent_tasks = self._visible_tasks_split()
         self._populate_one_table(self.query_one("#task-table", DataTable), main_tasks)
@@ -3119,9 +3322,11 @@ class WorkloadTracker(App):
         return main, recurrent
 
     def _visible_tasks(self) -> list:
+        # Every task in data["tasks"] is now a real unit of work: the shadow
+        # tasks the old cross-sprint split created are gone (converted into
+        # sprint_issues bindings by load_data()'s migration), so there is nothing
+        # left to hide here.
         tasks = self._data.get("tasks", [])
-        # Always hide shadow tasks (cross-sprint splits)
-        tasks = [t for t in tasks if not t.get("cross_sprint_parent")]
         if self.filter_role != "all":
             tasks = [t for t in tasks if t.get("role_id") == self.filter_role]
         if not self.show_done:
@@ -3323,7 +3528,7 @@ class WorkloadTracker(App):
         save_data(self._data)
 
         # Sync hours to GitHub project if task has linked issue
-        if task.get("github_issue"):
+        if task_current_issue(task, self._data):
             self._sync_task_hours_async(task)
 
         # Notify user
@@ -3337,13 +3542,16 @@ class WorkloadTracker(App):
     @work(thread=True)
     def _sync_task_hours_async(self, task: dict):
         """Sync task hours to GitHub project in background thread."""
-        issue_ref = task.get("github_issue")
+        issue_ref = task_current_issue(task, self._data)
         if not issue_ref:
             return
         self.call_from_thread(self._bg_start, "Syncing hours")
         try:
             if sync_project_hours(issue_ref, task, self._data, save_data):
-                hours = mins_to_quarter_hours(task_logged_mins(task))
+                # Report what sync_project_hours actually pushed: the current
+                # binding's sprint hours, not the task total (which for a
+                # carry-over task also covers sprints billed to other issues).
+                hours = mins_to_quarter_hours(task_reportable_mins(task, self._sprints()))
                 self.call_from_thread(
                     self.notify, f"Synced {hours}h to {issue_ref}", severity="information"
                 )
@@ -3427,7 +3635,7 @@ class WorkloadTracker(App):
             task = res["task"]
             self.call_from_thread(
                 self.notify,
-                f"Created: {task['title']} ({task['github_issue']})",
+                f"Created: {task['title']} ({task_current_issue(task, self._data)})",
                 severity="information",
             )
             self.call_from_thread(self._populate_table)
@@ -3528,15 +3736,17 @@ class WorkloadTracker(App):
         existing = next((i for i, t in enumerate(tasks) if t["id"] == result["id"]), None)
         is_new = existing is None
 
-        # Auto-assign current sprint for new tasks if not set by modal
-        if is_new and not result.get("sprint_id") and self._sprints_cache:
-            from datetime import datetime
-            today = datetime.now().date()
-            for s in self._sprints_cache:
-                if s["start_date"] <= today < s["end_date"]:
-                    result["sprint"] = s["title"]
-                    result["sprint_id"] = s["id"]
-                    break
+        # Auto-assign the current sprint to a new task. `sprint`/`sprint_id` are
+        # still written because `wt add` does (and set_task_current_issue() picks
+        # the binding to fill from task["sprint_id"]); `start_sprint*` is the
+        # Phase-3 field — a task created today starts in today's sprint.
+        if is_new and not result.get("sprint_id"):
+            current = self._current_sprint()
+            if current:
+                result["sprint"] = current["title"]
+                result["sprint_id"] = current["id"]
+                result.setdefault("start_sprint", current["title"])
+                result.setdefault("start_sprint_id", current["id"])
 
         if existing is not None:
             tasks[existing] = result
@@ -3545,7 +3755,7 @@ class WorkloadTracker(App):
         save_data(self._data)
 
         # Update GitHub issue title if needed
-        if title_changed and result.get("github_issue"):
+        if title_changed and task_current_issue(result, self._data):
             self._update_github_issue_title(result)
 
         # Create GitHub issue for new task if requested
@@ -3558,13 +3768,19 @@ class WorkloadTracker(App):
 
     @work(thread=True)
     def _update_github_issue_title(self, task: dict):
-        """Update GitHub issue title in background thread."""
+        """Update GitHub issue title in background thread.
+
+        Only the *current* binding's issue is retitled. Past-sprint issues keep
+        the title they were closed with (they are historical records, and they
+        carry a ``(Sprint N)`` suffix the new title wouldn't have anyway).
+        """
+        issue_ref = task_current_issue(task, self._data)
         self.call_from_thread(self._bg_start, "Updating issue title")
         try:
             from wt import update_issue_title
-            if update_issue_title(task["github_issue"], task["title"]):
+            if update_issue_title(issue_ref, task["title"]):
                 self.call_from_thread(
-                    self.notify, f"Updated GitHub issue: {task['github_issue']}", severity="information"
+                    self.notify, f"Updated GitHub issue: {issue_ref}", severity="information"
                 )
             else:
                 self.call_from_thread(
@@ -3584,9 +3800,9 @@ class WorkloadTracker(App):
             return
         self.call_from_thread(self._bg_start, "Creating GitHub issue")
         try:
-            # Create the issue
+            # Create the issue and bind it to the task's current sprint.
             issue_ref = create_github_issue(task, repo)
-            task["github_issue"] = issue_ref
+            set_task_current_issue(task, issue_ref, self._data)
             save_data(self._data)
             self.call_from_thread(
                 self.notify, f"Created issue: {issue_ref}", severity="information"
@@ -3596,7 +3812,8 @@ class WorkloadTracker(App):
             result = setup_issue_in_project(issue_ref, task, self._data)
             if result["success"]:
                 save_data(self._data)  # Save uploaded_at markers
-                hours = mins_to_quarter_hours(task_logged_mins(task))
+                # setup_issue_in_project() sets Hours from task_reportable_mins.
+                hours = mins_to_quarter_hours(task_reportable_mins(task, self._sprints()))
                 self.call_from_thread(
                     self.notify, f"Added to project: {hours}h", severity="information"
                 )
@@ -3620,7 +3837,7 @@ class WorkloadTracker(App):
         if not task:
             return
 
-        if task.get("github_issue"):
+        if task_current_issue(task, self._data):
             # Issue exists - offer to sync project fields
             self._sync_existing_issue(task)
             return
@@ -3629,10 +3846,11 @@ class WorkloadTracker(App):
         if not repo:
             self.notify("No GitHub repo set on this task (edit with 'e')", severity="warning")
             return
-        # Show modal with project field preview
-        logged_mins = task_logged_mins(task)
+        # Show modal with project field preview. The Hours preview has to match
+        # what setup_issue_in_project() will push, i.e. the sprint-filtered total.
+        logged_mins = task_reportable_mins(task, self._sprints())
         activity = get_task_activity(task)
-        sprint = get_current_sprint(self._data)
+        sprint = self._current_sprint()
         sprint_title = sprint["title"] if sprint else None
         status = task.get("status", "todo")
         self.push_screen(
@@ -3642,15 +3860,19 @@ class WorkloadTracker(App):
 
     def _sync_existing_issue(self, task: dict):
         """Sync project fields for an existing GitHub issue."""
-        logged_mins = task_logged_mins(task)
+        sprints = self._sprints()
+        logged_mins = task_reportable_mins(task, sprints)
         activity = get_task_activity(task)
-        sprint = get_current_sprint(self._data)
-        sprint_title = sprint["title"] if sprint else None
+        binding = current_binding(task, self._data)
+        sprint_title = (binding or {}).get("sprint") or (
+            (self._current_sprint() or {}).get("title")
+        )
         status = task.get("status", "todo")
         hours = mins_to_quarter_hours(logged_mins) if logged_mins > 0 else 0
 
         self.push_screen(
-            SyncIssueModal(task["title"], task["github_issue"], status, activity, sprint_title, hours),
+            SyncIssueModal(task["title"], task_current_issue(task, self._data),
+                           status, activity, sprint_title, hours),
             lambda confirmed: self._on_sync_issue_confirmed(task, confirmed)
         )
 
@@ -3663,7 +3885,7 @@ class WorkloadTracker(App):
     @work(thread=True)
     def _sync_issue_to_project(self, task: dict):
         """Sync all project fields for an existing issue."""
-        issue_ref = task.get("github_issue")
+        issue_ref = task_current_issue(task, self._data)
         if not issue_ref:
             return
 
@@ -3672,9 +3894,9 @@ class WorkloadTracker(App):
             result = setup_issue_in_project(issue_ref, task, self._data)
             if result["success"]:
                 save_data(self._data)
-                hours = mins_to_quarter_hours(task_logged_mins(task))
-                sprint = get_current_sprint(self._data)
-                sprint_title = sprint["title"] if sprint else "N/A"
+                hours = mins_to_quarter_hours(task_reportable_mins(task, self._sprints()))
+                sprint = (current_binding(task, self._data) or {}).get("sprint")
+                sprint_title = sprint or (self._current_sprint() or {}).get("title") or "N/A"
                 self.call_from_thread(
                     self.notify, f"Synced to project: {hours}h, {sprint_title}", severity="information"
                 )
@@ -3691,7 +3913,7 @@ class WorkloadTracker(App):
         task = self._selected_task()
         if not task:
             return
-        if not task.get("github_issue"):
+        if not task_current_issue(task, self._data):
             self.notify("No GitHub issue linked", severity="warning")
             return
         self._bg_start("Updating GitHub")
@@ -3701,10 +3923,11 @@ class WorkloadTracker(App):
     def _update_github_project(self, task: dict):
         """Push current task state to GitHub project in background."""
         try:
-            result = setup_issue_in_project(task["github_issue"], task, self._data)
+            result = setup_issue_in_project(
+                task_current_issue(task, self._data), task, self._data)
             if result["success"]:
                 save_data(self._data)
-                hours = mins_to_quarter_hours(task_logged_mins(task))
+                hours = mins_to_quarter_hours(task_reportable_mins(task, self._sprints()))
                 self.call_from_thread(
                     self.notify, f"GitHub updated: {hours}h", severity="information"
                 )
@@ -3727,7 +3950,7 @@ class WorkloadTracker(App):
         task = self._selected_task()
         if not task:
             return
-        issue_ref = task.get("github_issue")
+        issue_ref = task_current_issue(task, self._data)
         if not issue_ref:
             self.notify("No GitHub issue linked to this task", severity="warning")
             return
@@ -3742,11 +3965,15 @@ class WorkloadTracker(App):
         self.notify(f"Opened: {issue_ref}", severity="information")
 
     def action_delete_github_issue(self):
-        """Delete the GitHub issue linked to the selected task."""
+        """Delete the GitHub issue linked to the selected task.
+
+        Only the current binding's issue — past-sprint issues stay put (they hold
+        hours already reported for closed sprints).
+        """
         task = self._selected_task()
         if not task:
             return
-        issue_ref = task.get("github_issue")
+        issue_ref = task_current_issue(task, self._data)
         if not issue_ref:
             self.notify("No GitHub issue linked to this task", severity="warning")
             return
@@ -3764,10 +3991,13 @@ class WorkloadTracker(App):
     @work(thread=True)
     def _delete_github_issue_worker(self, task: dict):
         """Delete GitHub issue in background thread."""
-        issue_ref = task["github_issue"]
+        issue_ref = task_current_issue(task, self._data)
         try:
             if delete_github_issue(issue_ref):
-                del task["github_issue"]
+                # Unlinks the ref from whichever binding holds it (the binding
+                # itself survives — bindings are never deleted, plan §2.3 step 6)
+                # and drops the legacy flat key.
+                clear_task_current_issue(task, self._data)
                 save_data(self._data)
                 self.call_from_thread(
                     self.notify, f"Deleted issue: {issue_ref}", severity="information"
@@ -3795,7 +4025,10 @@ class WorkloadTracker(App):
         task = next((t for t in self._data["tasks"] if t["id"] == task_id), None)
         if not task:
             return
-        issue_ref = task.get("github_issue")
+        # Only the current binding's issue is deleted with the task. Past-sprint
+        # issues are left alone, matching the pre-Phase-3 behaviour where each
+        # past sprint lived on its own shadow *task* that this delete never saw.
+        issue_ref = task_current_issue(task, self._data)
         if self._is_running(task):
             self._data["active_timer"] = None
         self._data["tasks"] = [t for t in self._data["tasks"] if t["id"] != task_id]
@@ -3853,7 +4086,7 @@ class WorkloadTracker(App):
         save_data(self._data)
 
         # Sync hours to GitHub project if task has linked issue
-        if task and task.get("github_issue"):
+        if task and task_current_issue(task, self._data):
             self._sync_task_hours_async(task)
 
         # Safari window integration: snapshot+close the stopped task's window
@@ -3891,7 +4124,7 @@ class WorkloadTracker(App):
                     stopped_task = prev
                     save_data(self._data)
                     # Sync hours for the stopped task
-                    if prev.get("github_issue"):
+                    if task_current_issue(prev, self._data):
                         self._sync_task_hours_async(prev)
 
             self._data["active_timer"] = {"task_id": task["id"], "started_at": time.time()}
@@ -4074,7 +4307,7 @@ class WorkloadTracker(App):
         task["status"] = "inprogress"
         save_data(self._data)
         self._populate_table()
-        if task.get("github_issue"):
+        if task_current_issue(task, self._data):
             self._sync_project_status_async(task, "inprogress")
 
     def action_mark_done(self):
@@ -4093,12 +4326,10 @@ class WorkloadTracker(App):
         # Recurrent tasks in the current sprint need an extra confirmation
         # before we close them and their GitHub issue.
         if current == "recurrent":
-            current_sprint = get_current_sprint(self._data)
-            task_sprint_id = task.get("sprint_id")
-            in_current_sprint = (
-                current_sprint is not None
-                and task_sprint_id is not None
-                and task_sprint_id == current_sprint["id"]
+            current_sprint = self._current_sprint()
+            in_current_sprint = current_sprint is not None and (
+                task_binding_for_sprint(task, current_sprint["id"]) is not None
+                or task.get("sprint_id") == current_sprint["id"]
             )
             if in_current_sprint:
                 self.push_screen(
@@ -4125,20 +4356,20 @@ class WorkloadTracker(App):
         repo = get_task_repo(task)
 
         # If task already has a GitHub issue, always show confirmation and update project
-        if task.get("github_issue"):
+        if task_current_issue(task, self._data):
             self._fetch_gh_hours_and_confirm_close(task)
             return
 
         # Task has no GitHub issue - check if it has a repo to create one
         if repo:
             # Prompt to create issue with project field preview
-            logged_mins = task_logged_mins(task)
+            logged_mins = task_reportable_mins(task, self._sprints())
             activity = get_task_activity(task)
-            sprint = get_current_sprint(self._data)
+            sprint = self._current_sprint()
             sprint_title = sprint["title"] if sprint else None
             self.push_screen(
                 CreateIssueModal(task["title"], repo, logged_mins, activity, sprint_title, "done"),
-                lambda confirmed: self._on_create_issue_for_close(task, repo, confirmed)
+                lambda confirmed: self._on_create_issue_for_close(task, confirmed)
             )
         else:
             # No GitHub integration - confirm before closing
@@ -4169,19 +4400,35 @@ class WorkloadTracker(App):
     def _fetch_gh_hours_worker(self, task: dict):
         """Fetch GitHub project hours in background."""
         try:
-            gh_hours = None
-            if task.get("github_issue"):
-                gh_hours = get_project_hours(task["github_issue"], self._data)
+            issue_ref = task_current_issue(task, self._data)
+            gh_hours = get_project_hours(issue_ref, self._data) if issue_ref else None
 
-            local_mins = task_logged_mins(task)
-            self.call_from_thread(self._show_close_confirmation, task, local_mins, gh_hours)
+            # Compare like with like: the close pushes the *current sprint's*
+            # hours to this issue, not the task total, so that is what the modal
+            # must show. The total is passed alongside for context when they
+            # differ (a carry-over task whose earlier sprints are billed to
+            # their own issues).
+            sprints = self._sprints()
+            local_mins = task_reportable_mins(task, sprints)
+            total_mins = task_logged_mins(task)
+            # Sprints with >0 logged minutes (task_sprints_with_time, the
+            # start_date-sorted replacement for sprint_summary_for_task).
+            n_sprints = len(task_sprints_with_time(task, sprints)) if sprints else 0
+            binding = current_binding(task, self._data)
+            sprint_title = (binding or {}).get("sprint") or task.get("sprint")
+            self.call_from_thread(self._show_close_confirmation, task, local_mins,
+                                  gh_hours, sprint_title, total_mins, n_sprints)
         finally:
             self.call_from_thread(self._bg_end, "Fetching GitHub hours")
 
-    def _show_close_confirmation(self, task: dict, local_mins: float, gh_hours: float | None):
+    def _show_close_confirmation(self, task: dict, local_mins: float, gh_hours: float | None,
+                                 sprint_title: str | None = None,
+                                 total_mins: float | None = None, n_sprints: int = 0):
         """Show the close confirmation modal with hours comparison."""
         self.push_screen(
-            ConfirmCloseTaskModal(task["title"], local_mins, gh_hours),
+            ConfirmCloseTaskModal(task["title"], local_mins, gh_hours,
+                                  sprint_title=sprint_title, total_mins=total_mins,
+                                  n_sprints=n_sprints),
             lambda confirmed: self._on_close_confirmed(task, confirmed)
         )
 
@@ -4191,105 +4438,105 @@ class WorkloadTracker(App):
             return
         self._complete_close_workflow(task)
 
-    def _on_create_issue_for_close(self, task: dict, repo: str, confirmed: bool):
+    def _on_create_issue_for_close(self, task: dict, confirmed: bool):
         """Handle response from create issue modal during close workflow."""
         if not confirmed:
             self.notify("Task must have GitHub issue to close (task has a repo configured)", severity="warning")
             return
 
         # Run blocking GitHub operations in a worker thread
-        self._run_close_workflow(task, repo, create_issue=True)
-
-    def _on_create_issue_response(self, task: dict, repo: str, create: bool):
-        """Handle response from create issue modal."""
-        if not create:
-            self.notify("Task must have GitHub issue to close (task has a repo configured)", severity="warning")
-            return
-
-        # Run blocking GitHub operations in a worker thread
-        self._run_close_workflow(task, repo, create_issue=True)
+        self._run_close_workflow(task, create_issue=True)
 
     @work(thread=True)
-    def _run_close_workflow(self, task: dict, repo: str, create_issue: bool = False):
-        """Run the close workflow in a background thread to avoid blocking."""
+    def _run_close_workflow(self, task: dict, create_issue: bool = False):
+        """Run the close workflow in a background thread to avoid blocking.
+
+        Phase 3 replaced this method's hand-rolled copy of the close steps with a
+        call to :func:`wt.close_task`, the same function ``wt done`` and the MCP
+        server use. That is what brings the TUI in line with Option A of the plan
+        (§2.4): before any hours are reported, ``close_task`` reconciles the
+        task's per-sprint bindings, so each earlier sprint's hours land on their
+        own issue and the current issue is told only its own sprint's total. The
+        old inline version pushed ``task_logged_mins(task)`` — the whole task
+        total — to the single linked issue, which double-counted every carry-over.
+
+        Behaviour that is deliberately preserved:
+          * the user has already confirmed via CreateIssueModal /
+            ConfirmCloseTaskModal, so ``prompt_callback`` just says yes when this
+            was invoked with ``create_issue=True`` and is absent otherwise;
+          * no closing-comment prompt (``comment_callback=None``), as before;
+          * a failed ``gh issue close`` still leaves the task marked done locally
+            (``close_task`` warns via its result rather than raising);
+          * a failed *reconcile* aborts the close and leaves the task open —
+            matching ``wt done``, so hours can never be mis-reported.
+        """
         self.call_from_thread(self._bg_start, "Closing task")
         try:
-            # Create issue if needed
-            if create_issue:
-                try:
-                    issue_ref = create_github_issue(task, repo)
-                    task["github_issue"] = issue_ref
-                    save_data(self._data)
-                    self.call_from_thread(self.notify, f"Created issue: {issue_ref}", severity="information")
+            res = wt_close_task(
+                task, self._data, save_data,
+                prompt_callback=(lambda _msg: True) if create_issue else None,
+            )
 
-                    # Set up project fields for new issue (status, activity, sprint, hours)
-                    result = setup_issue_in_project(issue_ref, task, self._data)
-                    if result["success"]:
-                        save_data(self._data)
-                except Exception as e:
-                    self.call_from_thread(self.notify, f"Failed to create issue: {e}", severity="error")
-                    return
+            if res.get("issue_created"):
+                self.call_from_thread(
+                    self.notify,
+                    f"Created issue: {task_current_issue(task, self._data)}",
+                    severity="information",
+                )
 
-            # Update project if configured
-            config = self._data.get("config", {})
-            if config.get("github_project_number"):
-                try:
-                    total_mins = task_logged_mins(task)
-                    hours = mins_to_quarter_hours(total_mins)
-                    add_to_project_and_update(task["github_issue"], hours, self._data)
-
-                    # Mark logs as uploaded
-                    from wt import mark_logs_uploaded, update_project_sprint
-                    mark_logs_uploaded(task)
-                    save_data(self._data)
-
-                    # Set activity if the task has one
-                    activity = get_task_activity(task)
-                    if activity:
-                        update_project_activity(task["github_issue"], activity, self._data)
-
-                    # Set type if the task has one
-                    type_val = get_task_type(task)
-                    if type_val:
-                        update_project_type(task["github_issue"], type_val, self._data)
-
-                    # Set sprint from task's stored sprint
-                    sprint_id = task.get("sprint_id")
-                    if sprint_id:
-                        sprints = get_all_sprints(self._data)
-                        field_id = sprints[0]["field_id"] if sprints else None
-                        if field_id:
-                            update_project_sprint(task["github_issue"], sprint_id, field_id, self._data)
-
-                    self.call_from_thread(self.notify, f"Updated project (Hours: {hours}h, Sprint: {task.get('sprint', '?')})", severity="information")
-                except Exception as e:
-                    self.call_from_thread(self.notify, f"Project update failed: {e}", severity="warning")
-
-            # Close the GitHub issue. Failures here must not prevent the local
-            # status update — the user already confirmed they want the task closed.
-            if task.get("github_issue"):
-                try:
-                    if close_github_issue(task["github_issue"]):
-                        self.call_from_thread(self.notify, f"Closed issue: {task['github_issue']}", severity="information")
-                    else:
-                        self.call_from_thread(
-                            self.notify,
-                            f"Failed to close issue {task['github_issue']} (gh returned non-zero). Task marked done locally.",
-                            severity="warning",
-                        )
-                except Exception as e:
+            # Per-sprint reconcile summary, rendered exactly like `wt done`.
+            rec = res.get("reconcile_result")
+            if rec:
+                for line in _reconcile_outcome_lines(rec):
                     self.call_from_thread(
-                        self.notify,
-                        f"Error closing issue {task['github_issue']}: {e}. Task marked done locally.",
-                        severity="warning",
+                        self.notify, esc(line),
+                        title="Sprint reconcile",
+                        severity="warning" if line.startswith(("✗", "!")) else "information",
+                        timeout=8,
                     )
 
-            # Mark as done
-            task["status"] = "done"
-            save_data(self._data)
+            if not res.get("success"):
+                self.call_from_thread(
+                    self.notify,
+                    esc(res.get("error") or "Close failed"),
+                    severity="error",
+                    timeout=10,
+                )
+                # Reconcile/issue-creation failures leave the task open on
+                # purpose; still re-render so any bindings it did create show up.
+                self.call_from_thread(self._bridge_refresh_ui)
+                return
+
+            if res.get("project_updated"):
+                sprints = self._sprints()
+                hours = mins_to_quarter_hours(task_reportable_mins(task, sprints))
+                sprint_label = (current_binding(task, self._data) or {}).get("sprint") \
+                    or task.get("sprint", "?")
+                self.call_from_thread(
+                    self.notify,
+                    f"Updated project (Hours: {hours}h, Sprint: {sprint_label})",
+                    severity="information",
+                )
+            elif res.get("error"):
+                # close_task reports a non-fatal project failure this way.
+                self.call_from_thread(self.notify, esc(res["error"]), severity="warning")
+
+            issue_ref = task_current_issue(task, self._data)
+            if res.get("issue_closed"):
+                self.call_from_thread(
+                    self.notify, f"Closed issue: {issue_ref}", severity="information")
+            elif issue_ref and not res.get("skipped_github"):
+                self.call_from_thread(
+                    self.notify,
+                    f"Failed to close issue {issue_ref} (gh returned non-zero). "
+                    f"Task marked done locally.",
+                    severity="warning",
+                )
 
             # Update UI from main thread
             self.call_from_thread(self._finish_close_workflow, task)
+        except Exception as e:
+            self.call_from_thread(self.notify, f"Close failed: {e}", severity="error")
         finally:
             self.call_from_thread(self._bg_end, "Closing task")
 
@@ -4302,7 +4549,94 @@ class WorkloadTracker(App):
 
     def _complete_close_workflow(self, task: dict):
         """Complete the close workflow for task that already has an issue."""
-        self._run_close_workflow(task, "", create_issue=False)
+        self._run_close_workflow(task, create_issue=False)
+
+    # ── Sprint bindings reconcile (`S`) ───────────────────
+
+    def action_sync_sprints(self):
+        """Reconcile the selected task's per-sprint issue bindings with its logs.
+
+        The in-TUI equivalent of ``wt sync-sprints <task>`` (plan §2.3): work that
+        crossed a sprint boundary gets one issue per sprint, each carrying that
+        sprint's hours, past ones closed. Replaces the old "use 'wt split-sprint'"
+        notification with something the user can actually act on.
+
+        A dry run is computed first and shown for confirmation.
+        ``reconcile_task_sprints(..., dry_run=True)`` is structurally write-free
+        (it returns the pure plan without executing it) and makes no network call,
+        so it is safe to run here on the event loop.
+        """
+        task = self._selected_task()
+        if not task:
+            return
+        # Recurrent tasks are deliberately excluded: they intentionally span
+        # sprints with one per-sprint copy each, and are handled by
+        # `wt close-recurrent` / `wt new-recurrent`. Reconciling them would mint a
+        # past-sprint issue for every copy. (Unifying the two models is Phase 5.)
+        if task.get("status") == "recurrent":
+            self.notify(
+                "Recurrent tasks are handled by 'wt close-recurrent' / "
+                "'wt new-recurrent', not by a sprint reconcile.",
+                severity="warning",
+            )
+            return
+
+        sprints = self._sprints()
+        if not sprints:
+            self.notify("No sprint list available yet (project not configured?)",
+                        severity="warning")
+            return
+
+        plan = reconcile_task_sprints(task, self._data, sprints, dry_run=True)
+        if plan.get("error"):
+            self.notify(esc(plan["error"]), severity="error")
+            return
+        lines = _reconcile_plan_lines(plan)
+        if not lines:
+            self.notify(f"'{esc(task['title'])}' is already in sync with its logs.",
+                        severity="information")
+            return
+        breakdown = ", ".join(
+            f"{e['sprint']}={fmt_mins(e['minutes'])}" for e in plan.get("target", [])
+        )
+        n_new = sum(1 for op in plan.get("planned", [])
+                    if op["op"] == "create" and op.get("create_issue"))
+        self.push_screen(
+            SyncSprintsModal(task["title"], breakdown, lines, n_new),
+            lambda confirmed: self._on_sync_sprints_confirmed(task, confirmed),
+        )
+
+    def _on_sync_sprints_confirmed(self, task: dict, confirmed: bool):
+        if not confirmed:
+            return
+        self._bg_start("Syncing sprints")
+        self._sync_sprints_worker(task)
+
+    @work(thread=True)
+    def _sync_sprints_worker(self, task: dict):
+        """Execute the reconcile (creates/closes GitHub issues) off the event loop."""
+        try:
+            # save_callback runs after each created binding, so an interrupted
+            # run never loses an issue it just minted; the final save covers the
+            # hours/close bookkeeping.
+            res = reconcile_task_sprints(
+                task, self._data, self._sprints(), save_callback=save_data,
+            )
+            save_data(self._data)
+            lines = _reconcile_outcome_lines(res) or ["(nothing to do)"]
+            for line in lines:
+                self.call_from_thread(
+                    self.notify, esc(line),
+                    title="Sprint reconcile",
+                    severity="warning" if line.startswith(("✗", "!")) else "information",
+                    timeout=8,
+                )
+        except Exception as e:
+            self.call_from_thread(self.notify, f"Sprint reconcile failed: {e}",
+                                  severity="error")
+        finally:
+            self.call_from_thread(self._bg_end, "Syncing sprints")
+            self.call_from_thread(self._bridge_refresh_ui)
 
     def _arc_on_task_completed(self, task: dict):
         """Arc integration: archive tabs and remove folder when task is done."""
@@ -4321,7 +4655,7 @@ class WorkloadTracker(App):
         """Sync task status to GitHub project in background thread."""
         self.call_from_thread(self._bg_start, "Syncing status")
         try:
-            if sync_project_status(task["github_issue"], status, self._data):
+            if sync_project_status(task_current_issue(task, self._data), status, self._data):
                 status_label = {"todo": "Todo", "inprogress": "In Progress", "done": "Done"}.get(status, status)
                 self.call_from_thread(self.notify, f"Project status: {status_label}", severity="information")
         finally:
@@ -4379,10 +4713,14 @@ class WorkloadTracker(App):
         }
 
     def _bridge_list_tasks(self) -> dict:
-        """Non-done, non-shadow tasks for the client's task picker."""
+        """Non-done tasks for the client's task picker.
+
+        The old shadow-task exclusion is gone — cross-sprint work is now one task
+        with several issue bindings, so every entry here is a real unit of work.
+        """
         tasks = []
         for t in self._data.get("tasks", []):
-            if t.get("status") == "done" or t.get("cross_sprint_parent"):
+            if t.get("status") == "done":
                 continue
             tasks.append({
                 "id": t["id"],
@@ -4490,7 +4828,7 @@ class WorkloadTracker(App):
         if not task:
             return {"error": f"No task matching '{query}'", "_status": 404}
 
-        issue_ref = task.get("github_issue")
+        issue_ref = task_current_issue(task, wt_data)
         if not issue_ref:
             return {"error": f"Task '{task['title']}' has no linked GitHub issue", "_status": 400}
 

--- a/wt.py
+++ b/wt.py
@@ -1658,19 +1658,594 @@ def _match_sprint(sprints: list[dict], query: str) -> dict | None:
     return None
 
 
+def _find_binding(bindings: list[dict], issue: str = None, sprint_id: str = None) -> dict | None:
+    """Locate a binding by issue ref first, then by sprint_id. None if absent.
+
+    Issue-ref lookup wins because a reconcile can re-point a binding's sprint,
+    but an issue ref, once minted, never moves to another binding.
+    """
+    if issue:
+        for b in bindings:
+            if b.get("issue") == issue:
+                return b
+    if sprint_id:
+        for b in bindings:
+            if b.get("sprint_id") == sprint_id:
+                return b
+    return None
+
+
+def _reconcile_plan(task: dict, data: dict, sprints: list[dict], *,
+                    create_issues: bool = True, close_past: bool = True,
+                    sync_hours: bool = True) -> dict:
+    """Pure planner behind :func:`reconcile_task_sprints` (plan §2.3).
+
+    Reads ``task``/``data``/``sprints`` and returns the ordered list of
+    operations that would bring the task's ``sprint_issues`` bindings in line
+    with what its logs say. **Mutates nothing and makes no GitHub call**, which
+    is what makes ``dry_run=True`` structurally airtight: the caller either
+    executes this plan or returns it untouched.
+
+    Returned dict:
+      ``error``              — fatal planning problem (no sprints), else None
+      ``current_sprint`` / ``current_sprint_id``
+      ``target``             — [{sprint_id, sprint, minutes, hours}], oldest first
+      ``ops``                — ordered ops, each a self-describing dict with an
+                               ``op`` of create/repoint/hours/close
+      ``skipped``            — no-ops worth reporting, each with a ``reason``
+      ``unassigned_minutes`` — minutes whose log timestamps fall in no sprint
+      ``seed_legacy``        — the task's legacy ``github_issue`` is not yet
+                               represented by a binding and must be seeded
+    """
+    plan = {
+        "error": None,
+        "current_sprint": None,
+        "current_sprint_id": None,
+        "target": [],
+        "ops": [],
+        "skipped": [],
+        "unassigned_minutes": 0.0,
+        "seed_legacy": False,
+    }
+
+    sprints = sprints or []
+    if not sprints:
+        plan["error"] = "No sprints found"
+        return plan
+
+    by_id = {s["id"]: s for s in sprints if s.get("id")}
+    today = datetime.now().date()
+    repo = get_task_repo(task)
+    has_project = bool(data.get("config", {}).get("github_project_number"))
+
+    def sort_key(sprint_id):
+        s = by_id.get(sprint_id)
+        return _sprint_start_sort_key(s.get("start_date") if s else None)
+
+    def ended(sprint_id):
+        s = by_id.get(sprint_id)
+        return bool(s and s.get("end_date") and s["end_date"] <= today)
+
+    # 1. Bucket logs by sprint; sprints with a zero total are not targets. Logs
+    #    that land outside every sprint are surfaced, never silently attributed.
+    plan["unassigned_minutes"] = sum(
+        l.get("minutes", 0) for l in bucket_logs_by_sprint(task, sprints).get(None, [])
+    )
+    targets = {e["sprint_id"]: e["total_mins"] for e in task_sprints_with_time(task, sprints)}
+
+    # 2. …plus the current sprint while the task is still open. This is what
+    #    makes the marker-log ritual of plan §1.3 unnecessary: an open task
+    #    always has a binding for new work to land on, even at 0 minutes.
+    current = find_sprint_for_date(sprints, today)
+    if current:
+        plan["current_sprint"] = current["title"]
+        plan["current_sprint_id"] = current["id"]
+        if task.get("status") != "done":
+            targets.setdefault(current["id"], 0.0)
+
+    target_ids = sorted((sid for sid in targets if sid in by_id), key=sort_key)
+    plan["target"] = [
+        {
+            "sprint_id": sid,
+            "sprint": by_id[sid]["title"],
+            "minutes": targets[sid],
+            "hours": mins_to_quarter_hours(targets[sid]) if targets[sid] > 0 else 0.0,
+        }
+        for sid in target_ids
+    ]
+
+    # Working copy of the existing bindings — planning never touches the real ones.
+    persisted = task.get("sprint_issues")
+    if isinstance(persisted, list):
+        work = [
+            {"sprint_id": b.get("sprint_id"), "issue": b.get("issue"),
+             "state": b.get("state"), "hours_synced": b.get("hours_synced")}
+            for b in persisted
+        ]
+        legacy_issue = task.get("github_issue")
+        if legacy_issue and not any(w["issue"] == legacy_issue for w in work):
+            # e.g. close_task() just minted the task's first issue and set only
+            # the legacy field. Adopt it rather than minting a second one.
+            seed = _legacy_binding_for_task(task)
+            work.append({"sprint_id": seed["sprint_id"], "issue": seed["issue"],
+                         "state": seed["state"], "hours_synced": None})
+            plan["seed_legacy"] = True
+    else:
+        work = []
+        seed = _legacy_binding_for_task(task)
+        if seed:
+            work.append({"sprint_id": seed["sprint_id"], "issue": seed["issue"],
+                         "state": seed["state"], "hours_synced": None})
+            plan["seed_legacy"] = True
+
+    bound = {w["sprint_id"] for w in work if w["sprint_id"] in by_id}
+
+    # Option A (plan §2.4): the task's *original* issue is the long-lived
+    # "current" one and moves forward across sprint boundaries; brand-new issues
+    # are minted for the sprints left behind. The carry-forward binding is the
+    # one holding that issue: the binding for the task's own sprint_id, else an
+    # unanchored binding (sprint unknown — a pre-sprint-tracking task).
+    own = task.get("sprint_id")
+    carry = None
+    if own:
+        carry = next((w for w in work if w["sprint_id"] == own and w["issue"]), None)
+    if carry is None:
+        carry = next((w for w in work if w["issue"] and w["sprint_id"] not in by_id), None)
+    if carry is None:
+        # `wt set-sprint` moves sprint_id without touching bindings, so the two
+        # can disagree. Fall back to the newest still-open issue — same rule as
+        # task_current_issue(). Without this we would mint a *second* issue for
+        # a sprint the task's live issue should simply have moved to.
+        still_open = sorted(
+            (w for w in work
+             if w["issue"] and w["state"] != "closed" and w["sprint_id"] in by_id),
+            key=lambda w: by_id[w["sprint_id"]]["start_date"],
+        )
+        carry = still_open[-1] if still_open else None
+    main_issue = carry["issue"] if carry else task.get("github_issue")
+
+    latest = target_ids[-1] if target_ids else None
+    if latest and latest not in bound and carry is not None:
+        carry_start = (by_id[carry["sprint_id"]]["start_date"]
+                       if carry["sprint_id"] in by_id else None)
+        # Never move an issue backwards in time.
+        if carry_start is None or carry_start < by_id[latest]["start_date"]:
+            plan["ops"].append({
+                "op": "repoint",
+                "sprint_id": latest,
+                "sprint": by_id[latest]["title"],
+                "from_sprint_id": carry["sprint_id"],
+                "from_sprint": (by_id[carry["sprint_id"]]["title"]
+                                if carry["sprint_id"] in by_id else None),
+                "issue": carry["issue"],
+                "minutes": targets[latest],
+                "hours": mins_to_quarter_hours(targets[latest]) if targets[latest] > 0 else 0.0,
+                "reason": "carry the task's current issue forward (Option A)",
+            })
+            bound.discard(carry["sprint_id"])
+            bound.add(latest)
+            carry["sprint_id"] = latest
+
+    # 3. Target sprints with no binding get one (plus a GH issue when possible).
+    has_issue_anywhere = any(w["issue"] for w in work)
+    missing = [sid for sid in target_ids if sid not in bound]
+    created_plan = []
+    for sid in missing:
+        sprint_title = by_id[sid]["title"]
+        minutes = targets[sid]
+        hours = mins_to_quarter_hours(minutes) if minutes > 0 else 0.0
+        will_close = bool(close_past and ended(sid))
+        # A past-sprint issue keeps today's " (Sprint N)" title suffix. Only a
+        # task that has no issue at all gets a plain-titled one, and only for
+        # its most recent sprint — matching create_github_issue()'s use in
+        # close_task()/wt add.
+        plain = (not has_issue_anywhere) and sid == latest
+        op = {
+            "op": "create",
+            "sprint_id": sid,
+            "sprint": sprint_title,
+            "minutes": minutes,
+            "hours": hours,
+            "issue": None,
+            "create_issue": bool(repo and create_issues),
+            "issue_title": task.get("title") if plain else f"{task.get('title')} ({sprint_title})",
+            "repo": repo,
+            "will_close": will_close,
+            "main_issue": main_issue,
+            "reason": ("sprint has logged time" if minutes > 0
+                       else "open task needs a binding for the current sprint"),
+        }
+        if not repo:
+            op["skipped_github"] = "task has no github_repo"
+        elif not create_issues:
+            op["skipped_github"] = "create_issues=False"
+        plan["ops"].append(op)
+        created_plan.append(op)
+
+    # Post-plan binding set: existing (possibly re-pointed) plus the new ones.
+    final = [
+        {"sprint_id": w["sprint_id"], "issue": w["issue"], "state": w["state"],
+         "hours_synced": w["hours_synced"], "new": False}
+        for w in work
+    ]
+    for op in created_plan:
+        # A created binding gets its hours pushed as part of creation, so it
+        # never needs a separate hours op.
+        final.append({"sprint_id": op["sprint_id"], "issue": None, "state": "open",
+                      "hours_synced": op["hours"], "new": True})
+
+    for sid in target_ids:
+        if sid in bound and sid != latest:
+            entry = next((f for f in final if f["sprint_id"] == sid), None)
+            plan["skipped"].append({
+                "sprint": by_id[sid]["title"], "sprint_id": sid,
+                "minutes": targets[sid], "issue": entry and entry.get("issue"),
+                "reason": "already bound",
+            })
+
+    # 4. Hours: push only when the value differs from what we last told GitHub.
+    for f in final:
+        sid = f["sprint_id"]
+        label = by_id[sid]["title"] if sid in by_id else (sid or "unknown sprint")
+        if sid not in by_id:
+            plan["skipped"].append({
+                "sprint": None, "sprint_id": sid, "issue": f["issue"],
+                "reason": "binding's sprint is not in the sprint list",
+            })
+            continue
+        if f["new"]:
+            continue
+        minutes = task_mins_for_sprint(task, sid, sprints)
+        hours = mins_to_quarter_hours(minutes) if minutes > 0 else 0.0
+        common = {"sprint": label, "sprint_id": sid, "issue": f["issue"],
+                  "minutes": minutes, "hours": hours,
+                  "from_hours": f["hours_synced"]}
+        if not f["issue"]:
+            plan["skipped"].append({**common, "reason": "binding has no issue"})
+        elif not sync_hours:
+            plan["skipped"].append({**common, "reason": "sync_hours=False"})
+        elif not has_project:
+            plan["skipped"].append({**common, "reason": "no github project configured"})
+        elif hours <= 0:
+            # Matches today's `if sprint_mins > 0` guard everywhere else: we
+            # never push a 0 to the project's Hours field.
+            plan["skipped"].append({**common, "reason": "no logged minutes"})
+        elif hours == f["hours_synced"]:
+            plan["skipped"].append({**common, "reason": "hours already synced"})
+        else:
+            plan["ops"].append({
+                "op": "hours", **common,
+                "reason": ("hours_synced unknown" if f["hours_synced"] is None
+                           else f"hours changed {f['hours_synced']} -> {hours}"),
+            })
+
+    # 5. Bindings whose sprint has ended are final: Status=Done + close.
+    for f in final:
+        sid = f["sprint_id"]
+        if sid not in by_id or not ended(sid):
+            continue
+        if f["state"] == "closed":
+            continue
+        if not close_past:
+            plan["skipped"].append({
+                "sprint": by_id[sid]["title"], "sprint_id": sid, "issue": f["issue"],
+                "reason": "close_past=False",
+            })
+            continue
+        plan["ops"].append({
+            "op": "close",
+            "sprint_id": sid,
+            "sprint": by_id[sid]["title"],
+            "issue": f["issue"],
+            "reason": "sprint has ended",
+        })
+
+    # Local-only: keep the legacy sprint/sprint_id pointing at whichever sprint
+    # the task's carried-forward "current" issue ends up bound to. Phase 3
+    # retires these fields; until then wt sprint, the TUI board and
+    # task_logged_mins_for_sprint() all read them. Listed as an op so an empty
+    # plan really means "nothing to do".
+    anchor = carry["sprint_id"] if (carry and carry["sprint_id"] in by_id) else latest
+    if anchor and task.get("sprint_id") != anchor:
+        own_start = by_id[own]["start_date"] if own in by_id else None
+        if own_start is not None and own_start > by_id[anchor]["start_date"]:
+            # Never walk the pointer backwards in time.
+            plan["skipped"].append({
+                "sprint": by_id[anchor]["title"], "sprint_id": anchor,
+                "reason": "would move the task's sprint pointer backwards",
+            })
+        else:
+            plan["ops"].append({
+                "op": "relabel",
+                "sprint_id": anchor,
+                "sprint": by_id[anchor]["title"],
+                "from_sprint_id": own,
+                "from_sprint": task.get("sprint"),
+                "reason": "legacy sprint/sprint_id follows the current issue's binding",
+            })
+
+    return plan
+
+
+def reconcile_task_sprints(task: dict, data: dict, sprints: list[dict], *,
+                           create_issues: bool = True, close_past: bool = True,
+                           sync_hours: bool = True, dry_run: bool = False,
+                           save_callback=None, progress_callback=None) -> dict:
+    """Bring a task's per-sprint issue bindings in line with its logs.
+
+    Implements plan §2.3 as a diff between the target state derived from
+    ``logs`` + ``sprints`` and the task's existing ``sprint_issues``:
+
+      1. Bucket logs by sprint; sprints with 0 minutes are not targets.
+      2. Target set = {sprints with time} ∪ {current sprint, if the task is
+         open}. The second term replaces the marker-log ritual (plan §1.3).
+      3. Target sprints with no binding get one, plus a GitHub issue when the
+         task has a ``github_repo`` and *create_issues* is set.
+      4. Every binding's hours are recomputed from the logs and pushed only
+         when they differ from the cached ``hours_synced``.
+      5. Bindings whose sprint has ended get Status=Done + a closed issue.
+      6. Bindings are never deleted and ``logs`` is never touched.
+
+    Which issue is "current" follows Option A of plan §2.4: the task's original
+    issue is carried forward to its most recent sprint and newly-minted issues
+    are for the sprints left behind (titled ``Task (Sprint N)``), which is
+    exactly what ``split_cross_sprint_task`` did on GitHub.
+
+    Idempotent: a second run plans nothing and calls nothing.
+
+    ``dry_run=True`` performs **zero** writes — no GitHub call, no mutation of
+    *task*/*data*, no ``save_callback`` — and returns the same result shape
+    describing what would happen. The plan is computed by the pure
+    :func:`_reconcile_plan` and only then executed, so this is structural
+    rather than a per-call-site check.
+
+    Args:
+        sprints: sprint list (``get_all_sprints`` or ``get_cached_sprints``).
+        create_issues: mint GitHub issues for new bindings.
+        close_past: close issues whose sprint has ended.
+        sync_hours: push recomputed hours to the project.
+        dry_run: plan only.
+        save_callback: called after each created binding and once at the end.
+        progress_callback: ``f(msg)`` progress updates.
+
+    Returns:
+        {success, error, dry_run, task, task_id, current_sprint, target,
+         planned, created, repointed, hours_updated, closed, relabeled,
+         skipped, errors, unassigned_minutes, bindings}
+
+        ``success`` is False if any per-sprint operation errored; the remaining
+        sprints are still processed and their results persisted.
+    """
+    def progress(msg):
+        if progress_callback:
+            progress_callback(msg)
+
+    plan = _reconcile_plan(task, data, sprints, create_issues=create_issues,
+                           close_past=close_past, sync_hours=sync_hours)
+
+    result = {
+        "success": plan["error"] is None,
+        "error": plan["error"],
+        "dry_run": bool(dry_run),
+        "task": task.get("title"),
+        "task_id": task.get("id"),
+        "current_sprint": plan["current_sprint"],
+        "target": plan["target"],
+        "planned": plan["ops"],
+        "created": [],
+        "repointed": [],
+        "hours_updated": [],
+        "closed": [],
+        "relabeled": None,
+        "skipped": list(plan["skipped"]),
+        "errors": [],
+        "unassigned_minutes": plan["unassigned_minutes"],
+        "bindings": [],
+    }
+
+    if plan["error"] or dry_run or not plan["ops"]:
+        result["bindings"] = [dict(b) for b in task_sprint_bindings(task, sprints)]
+        return result
+
+    # ---- execute -------------------------------------------------------------
+    by_id = {s["id"]: s for s in (sprints or []) if s.get("id")}
+    has_project = bool(data.get("config", {}).get("github_project_number"))
+    needs_project = any(
+        op["op"] in ("hours", "repoint", "close") or op.get("create_issue")
+        for op in plan["ops"]
+    )
+    pi = None
+    if has_project and needs_project:
+        progress("Fetching project info...")
+        try:
+            pi = get_project_info(data)
+        except Exception:
+            pi = None
+
+    bindings = task.get("sprint_issues")
+    if not isinstance(bindings, list):
+        bindings = []
+        task["sprint_issues"] = bindings
+    if plan["seed_legacy"]:
+        seed = _legacy_binding_for_task(task)
+        if seed:
+            _merge_binding(bindings, seed)
+
+    activity = get_task_activity(task)
+    type_val = get_task_type(task)
+    did_work = False
+    failed_sprints = set()
+
+    for op in plan["ops"]:
+        kind = op["op"]
+        sprint = by_id.get(op["sprint_id"])
+        label = op.get("sprint") or op["sprint_id"]
+        if op["sprint_id"] in failed_sprints:
+            # An earlier op for this sprint failed (e.g. issue creation), so the
+            # follow-ups have nothing to act on. One error per sprint, not three.
+            result["skipped"].append({
+                **op, "reason": "aborted: an earlier operation for this sprint failed",
+            })
+            continue
+        try:
+            if kind == "create":
+                binding = {
+                    "sprint_id": op["sprint_id"],
+                    "sprint": op["sprint"],
+                    "issue": None,
+                    "state": "open",
+                    "hours_synced": None,
+                    "synced_at": None,
+                    "created_at": time.time(),
+                }
+                if op["create_issue"]:
+                    progress(f"  {label}: Creating issue...")
+                    issue_ref = create_github_issue(
+                        {"id": uid(), "title": op["issue_title"]}, op["repo"]
+                    )
+                    binding["issue"] = issue_ref
+                    if pi:
+                        progress(f"  {label}: Adding to project...")
+                        item_id = add_issue_to_project(issue_ref, data)
+                        progress(f"  {label}: Setting fields...")
+                        if not op["will_close"]:
+                            # A close op below sets Status=Done; don't push twice.
+                            sync_project_status(issue_ref, task.get("status", "todo"),
+                                                data, project_info=pi, item_id=item_id)
+                        if op["hours"] > 0 and sync_hours:
+                            if update_project_hours(issue_ref, op["hours"], data,
+                                                    project_info=pi, item_id=item_id):
+                                binding["hours_synced"] = op["hours"]
+                                binding["synced_at"] = time.time()
+                        if sprint and sprint.get("field_id"):
+                            update_project_sprint(issue_ref, op["sprint_id"],
+                                                  sprint["field_id"], data,
+                                                  project_info=pi, item_id=item_id)
+                        if activity:
+                            update_project_activity(issue_ref, activity, data,
+                                                    project_info=pi, item_id=item_id)
+                        if type_val:
+                            update_project_type(issue_ref, type_val, data,
+                                                project_info=pi, item_id=item_id)
+                    if op.get("main_issue"):
+                        progress(f"  {label}: Adding comment...")
+                        add_issue_comment(
+                            binding["issue"],
+                            f"Sprint split from {op['main_issue']}. "
+                            "See that issue for full details and notes.",
+                        )
+                _merge_binding(bindings, binding)
+                if binding["issue"] and not task.get("github_issue"):
+                    task["github_issue"] = binding["issue"]
+                did_work = True
+                result["created"].append({
+                    "sprint": op["sprint"], "sprint_id": op["sprint_id"],
+                    "issue": binding["issue"], "minutes": op["minutes"],
+                    "hours": op["hours"],
+                    "skipped_github": op.get("skipped_github"),
+                })
+                if save_callback:
+                    save_callback(data)
+
+            elif kind == "repoint":
+                binding = _find_binding(bindings, issue=op["issue"],
+                                        sprint_id=op["from_sprint_id"])
+                if binding is None:
+                    raise Exception("binding to carry forward has disappeared")
+                binding["sprint_id"] = op["sprint_id"]
+                binding["sprint"] = op["sprint"]
+                if binding.get("issue") and pi and sprint and sprint.get("field_id"):
+                    progress(f"  {label}: Moving issue {binding['issue']} forward...")
+                    item_id = add_issue_to_project(binding["issue"], data)
+                    update_project_sprint(binding["issue"], op["sprint_id"],
+                                          sprint["field_id"], data,
+                                          project_info=pi, item_id=item_id)
+                did_work = True
+                result["repointed"].append({
+                    "sprint": op["sprint"], "sprint_id": op["sprint_id"],
+                    "from_sprint": op.get("from_sprint"), "issue": op["issue"],
+                })
+
+            elif kind == "hours":
+                binding = _find_binding(bindings, issue=op["issue"],
+                                        sprint_id=op["sprint_id"])
+                if binding is None:
+                    raise Exception("binding to sync hours for has disappeared")
+                progress(f"  {label}: Setting hours to {op['hours']}...")
+                item_id = add_issue_to_project(op["issue"], data)
+                if not update_project_hours(op["issue"], op["hours"], data,
+                                            project_info=pi, item_id=item_id):
+                    raise Exception(f"failed to set hours to {op['hours']}")
+                binding["hours_synced"] = op["hours"]
+                binding["synced_at"] = time.time()
+                did_work = True
+                result["hours_updated"].append({
+                    "sprint": op["sprint"], "sprint_id": op["sprint_id"],
+                    "issue": op["issue"], "minutes": op["minutes"],
+                    "hours": op["hours"], "from_hours": op.get("from_hours"),
+                })
+
+            elif kind == "close":
+                binding = _find_binding(bindings, issue=op["issue"],
+                                        sprint_id=op["sprint_id"])
+                if binding is None:
+                    raise Exception("binding to close has disappeared")
+                issue_ref = binding.get("issue")
+                if issue_ref:
+                    if pi:
+                        progress(f"  {label}: Setting Status=Done...")
+                        item_id = add_issue_to_project(issue_ref, data)
+                        sync_project_status(issue_ref, "done", data,
+                                            project_info=pi, item_id=item_id)
+                    progress(f"  {label}: Closing issue...")
+                    if not close_github_issue(issue_ref):
+                        raise Exception(f"failed to close issue {issue_ref}")
+                binding["state"] = "closed"
+                did_work = True
+                result["closed"].append({
+                    "sprint": op["sprint"], "sprint_id": op["sprint_id"],
+                    "issue": issue_ref,
+                })
+
+            elif kind == "relabel":
+                task["sprint_id"] = op["sprint_id"]
+                task["sprint"] = op["sprint"]
+                did_work = True
+                result["relabeled"] = {
+                    "sprint": op["sprint"], "sprint_id": op["sprint_id"],
+                    "from_sprint": op.get("from_sprint"),
+                }
+        except Exception as e:
+            result["errors"].append({**op, "error": str(e)})
+            result["success"] = False
+            failed_sprints.add(op["sprint_id"])
+
+    if did_work:
+        _dedupe_bindings(task)
+        _sort_task_bindings(task, sprints)
+        mark_logs_uploaded(task)
+        if save_callback:
+            save_callback(data)
+
+    result["bindings"] = [dict(b) for b in task_sprint_bindings(task, sprints)]
+    return result
+
+
 def split_cross_sprint_task(task: dict, data: dict, save_callback,
                             all_sprints: list[dict] = None,
                             progress_callback=None) -> dict:
-    """Split a task that has logs spanning multiple sprints.
+    """**Deprecated** — thin wrapper over :func:`reconcile_task_sprints`.
 
-    Creates shadow tasks for previous sprints with their own GH issues.
-    The original task is updated to the most recent sprint.
+    Kept so ``tracker.py``, ``mcp_server.py`` and ``cmd_split_sprint`` keep
+    working unchanged through Phase 2; Phase 3 migrates them to call reconcile
+    directly. The historical gate ("only has time in one sprint" → error) and
+    the return-dict keys ``success`` / ``sprint_tasks_created`` / ``main_sprint``
+    / ``error`` are preserved.
 
-    Args:
-        progress_callback: Optional function(msg) called with progress updates.
-
-    Returns dict with:
-        success, sprint_tasks_created, main_sprint, error
+    What changed underneath: previous sprints are recorded as ``sprint_issues``
+    bindings on the task instead of duplicate "shadow" task objects. The GitHub
+    side is unchanged — one issue per sprint, past ones titled
+    ``Task (Sprint N)``, closed, carrying that sprint's hours.
     """
     def progress(msg):
         if progress_callback:
@@ -1695,147 +2270,42 @@ def split_cross_sprint_task(task: dict, data: dict, save_callback,
         result["error"] = "Task only has time in one sprint"
         return result
 
-    # Most recent sprint (last in sorted list) stays on original task
-    main_sprint_info = summary[-1]
-    previous_sprints = summary[:-1]
+    rec = reconcile_task_sprints(task, data, all_sprints,
+                                 save_callback=save_callback,
+                                 progress_callback=progress_callback)
 
-    # Idempotency: the main task keeps all its logs (source of truth), so a
-    # re-split would otherwise re-detect the same previous sprints and create
-    # duplicate shadow tasks/issues. Skip any previous sprint already billed to
-    # its own issue — as a shadow task, or as a per-sprint binding once the
-    # shadow-to-bindings migration has removed those shadow objects.
-    existing_shadow_sprint_ids = existing_split_sprint_ids(task, data)
+    result["success"] = bool(rec.get("success"))
+    result["error"] = rec.get("error")
+    result["main_sprint"] = task.get("sprint") or (
+        rec["target"][-1]["sprint"] if rec.get("target") else None
+    )
 
-    repo = get_task_repo(task)
-    config = data.get("config", {})
-    has_project = bool(config.get("github_project_number"))
-
-    # Pre-fetch project info once (avoids repeated API calls)
-    pi = None
-    if has_project:
-        progress("Fetching project info...")
-        try:
-            pi = get_project_info(data)
-        except Exception:
-            pass
-
-    for sprint_info in previous_sprints:
-        sprint_label = sprint_info["sprint_title"]
-
-        # Skip sprints that were already split off into a shadow task.
-        if sprint_info["sprint_id"] in existing_shadow_sprint_ids:
+    for entry in rec.get("created", []):
+        result["sprint_tasks_created"].append({
+            "sprint": entry["sprint"],
+            "total_mins": entry["minutes"],
+            "issue_ref": entry.get("issue"),
+        })
+    for entry in rec.get("skipped", []):
+        if entry.get("reason") == "already bound":
             result["sprint_tasks_created"].append({
-                "sprint": sprint_label,
-                "total_mins": sprint_info["total_mins"],
+                "sprint": entry["sprint"],
+                "total_mins": entry.get("minutes", 0),
                 "issue_ref": None,
                 "skipped": "shadow already exists",
             })
-            continue
+    for entry in rec.get("errors", []):
+        result["sprint_tasks_created"].append({
+            "sprint": entry.get("sprint"),
+            "total_mins": entry.get("minutes", 0),
+            "issue_ref": entry.get("issue"),
+            "error": entry["error"],
+        })
+    if not result["success"] and not result["error"]:
+        result["error"] = "; ".join(
+            f"{e.get('sprint')}: {e['error']}" for e in rec.get("errors", [])
+        ) or "reconcile failed"
 
-        shadow_title = f"{task['title']} ({sprint_label})"
-        shadow_task = {
-            "id": uid(),
-            "title": shadow_title,
-            "description": f"Sprint split from: {task['title']}",
-            "role_id": task.get("role_id", "other"),
-            "status": "done",
-            "logs": [{
-                "id": uid(),
-                "minutes": sprint_info["total_mins"],
-                "note": f"Sprint split: {fmt_mins(sprint_info['total_mins'])} from {task['title']}",
-                "at": time.time(),
-            }],
-            "created_at": time.time(),
-            "sprint": sprint_label,
-            "sprint_id": sprint_info["sprint_id"],
-            "cross_sprint_parent": task["id"],
-        }
-        # Shadow tasks inherit the parent's GitHub fields
-        for key in _ROLE_GITHUB_FIELDS:
-            if task.get(key):
-                shadow_task[key] = task[key]
-
-        created_info = {
-            "sprint": sprint_label,
-            "total_mins": sprint_info["total_mins"],
-            "issue_ref": None,
-        }
-
-        # Create GH issue if the task has a repo
-        if repo:
-            try:
-                progress(f"  {sprint_label}: Creating issue...")
-                issue_ref = create_github_issue(
-                    {**shadow_task, "title": shadow_title}, repo
-                )
-                shadow_task["github_issue"] = issue_ref
-                created_info["issue_ref"] = issue_ref
-
-                if pi:
-                    progress(f"  {sprint_label}: Adding to project...")
-                    item_id = add_issue_to_project(issue_ref, data)
-
-                    progress(f"  {sprint_label}: Setting fields...")
-                    sync_project_status(issue_ref, "done", data, project_info=pi, item_id=item_id)
-
-                    hours = mins_to_quarter_hours(sprint_info["total_mins"])
-                    update_project_hours(issue_ref, hours, data, project_info=pi, item_id=item_id)
-
-                    if sprint_info.get("field_id"):
-                        update_project_sprint(
-                            issue_ref, sprint_info["sprint_id"],
-                            sprint_info["field_id"], data,
-                            project_info=pi, item_id=item_id
-                        )
-
-                    activity = get_task_activity(task)
-                    if activity:
-                        update_project_activity(issue_ref, activity, data, project_info=pi, item_id=item_id)
-
-                    type_val = get_task_type(task)
-                    if type_val:
-                        update_project_type(issue_ref, type_val, data, project_info=pi, item_id=item_id)
-
-                # Add comment linking to main task
-                main_issue = task.get("github_issue", "")
-                if main_issue:
-                    progress(f"  {sprint_label}: Adding comment...")
-                    comment = f"Sprint split from {main_issue}. See that issue for full details and notes."
-                    add_issue_comment(issue_ref, comment)
-
-                progress(f"  {sprint_label}: Closing issue...")
-                close_github_issue(issue_ref)
-                mark_logs_uploaded(shadow_task)
-
-            except Exception as e:
-                created_info["error"] = str(e)
-
-        data["tasks"].append(shadow_task)
-        result["sprint_tasks_created"].append(created_info)
-
-    # Update main task sprint to most recent
-    task["sprint"] = main_sprint_info["sprint_title"]
-    task["sprint_id"] = main_sprint_info["sprint_id"]
-    result["main_sprint"] = main_sprint_info["sprint_title"]
-
-    # Update main task's GH issue hours to only the most recent sprint's hours
-    if task.get("github_issue") and pi:
-        progress(f"  Main task: Updating hours and sprint...")
-        main_item_id = add_issue_to_project(task["github_issue"], data)
-        main_hours = mins_to_quarter_hours(main_sprint_info["total_mins"])
-        update_project_hours(task["github_issue"], main_hours, data, project_info=pi, item_id=main_item_id)
-        if main_sprint_info.get("field_id"):
-            update_project_sprint(
-                task["github_issue"], main_sprint_info["sprint_id"],
-                main_sprint_info["field_id"], data,
-                project_info=pi, item_id=main_item_id
-            )
-
-    # Mark all original task logs as uploaded
-    mark_logs_uploaded(task)
-    save_callback(data)
-
-    result["success"] = True
     return result
 
 
@@ -2394,6 +2864,14 @@ def close_task(task: dict, data: dict, save_callback, prompt_callback=None, comm
             add_to_project_and_update(task["github_issue"], hours, data)
             result["project_updated"] = True
 
+            # Record what GitHub was told on the matching binding, so a later
+            # reconcile doesn't re-push an identical value.
+            binding = _find_binding(task.get("sprint_issues") or [],
+                                    issue=task["github_issue"])
+            if binding is not None:
+                binding["hours_synced"] = hours
+                binding["synced_at"] = time.time()
+
             # Set activity if the task has one
             activity = get_task_activity(task)
             if activity:
@@ -2426,6 +2904,12 @@ def close_task(task: dict, data: dict, save_callback, prompt_callback=None, comm
     # 5. Close the GitHub issue
     if close_github_issue(task["github_issue"]):
         result["issue_closed"] = True
+        # Keep the binding's cached state honest, or a reconcile run after this
+        # sprint ends would try to close an already-closed issue.
+        binding = _find_binding(task.get("sprint_issues") or [],
+                                issue=task["github_issue"])
+        if binding is not None:
+            binding["state"] = "closed"
 
     # 6. Mark as done
     task["status"] = "done"

--- a/wt.py
+++ b/wt.py
@@ -56,6 +56,16 @@ Usage:
     wt roles update <id> <label>      — Update role label
     wt roles delete <id>              — Delete a role
 
+    wt sprint                         — Current sprint + active tasks by sprint
+    wt set-sprint <task> <sprint|none> — Correct the sprint a task STARTED in
+    wt sync-sprints <task>            — Reconcile a task's per-sprint GitHub
+                                        issues with its logs (idempotent)
+    wt sync-sprints --all [--create-issues] [--dry-run]
+                                      — Reconcile every non-recurrent task.
+                                        Never mints new issues unless
+                                        --create-issues is given; always prints
+                                        an itemised plan and asks first.
+
     wt set-repo <task> [repo]         — Set/clear GitHub repo for a task
     wt set-activity <task> [act]      — Set/clear GitHub Project activity for a task
     wt set-type <task> [type]         — Set/clear GitHub Project type for a task
@@ -567,7 +577,7 @@ def resolve_event_to_task(data: dict, event: dict) -> dict | None:
 
     The mapping value is a *base name* (sprint-suffix stripped). This function:
       1. Looks up the base name for ``event["title"]``.
-      2. Collects all non-shadow tasks whose ``strip_sprint_suffix(title)``
+      2. Collects all tasks whose ``strip_sprint_suffix(title)``
          matches that base name (case-insensitive).
       3. If the event's ``start_date`` resolves to a sprint, returns the
          candidate whose ``sprint_id`` matches.
@@ -585,8 +595,7 @@ def resolve_event_to_task(data: dict, event: dict) -> dict | None:
 
     candidates = [
         t for t in data.get("tasks", [])
-        if not t.get("cross_sprint_parent")
-        and strip_sprint_suffix(t.get("title", "")).lower() == base_lower
+        if strip_sprint_suffix(t.get("title", "")).lower() == base_lower
     ]
     if not candidates:
         return None
@@ -642,11 +651,19 @@ def task_logged_mins(task: dict) -> float:
 
 
 def task_logged_mins_for_sprint(task: dict, sprints: list) -> float:
-    """Sum log minutes that fall within the task's assigned sprint.
+    """**Deprecated** — use :func:`task_mins_for_sprint` / :func:`task_reportable_mins`.
+
+    Sum log minutes that fall within the task's assigned sprint.
 
     If the task has no sprint_id or sprint not found, returns total logged minutes.
     Used when reporting hours to GitHub: a task split across sprints keeps all
     logs locally but should only report its assigned sprint's hours to GH.
+
+    Kept only because ``mcp_server.py`` imports it. No ``wt.py`` code path calls
+    it any more: the "sprint unknown → report the task total" fallback silently
+    over-reports, so callers now go through ``task_reportable_mins()``, which
+    resolves the sprint from the task's *bindings* first and only falls back to
+    the total when no sprint can be resolved at all.
     """
     sprint_id = task.get("sprint_id")
     if not sprint_id or not sprints:
@@ -668,30 +685,6 @@ def task_logged_mins_for_sprint(task: dict, sprints: list) -> float:
         if sprint["start_date"] <= log_date < sprint["end_date"]:
             total += log.get("minutes", 0)
     return total
-
-
-def existing_split_sprint_ids(task: dict, data: dict) -> set:
-    """Sprints of *task* that a previous split already billed to their own issue.
-
-    Union of two representations of the same fact, so the split stays idempotent
-    across the Phase-1 migration:
-      * legacy shadow task objects (``cross_sprint_parent == task["id"]``), and
-      * the task's own ``sprint_issues`` bindings other than the one for its
-        current ``sprint_id`` (which is the main issue, not a split-off one).
-
-    Before migration this returns exactly the old shadow-id set.
-    """
-    ids = {
-        t.get("sprint_id")
-        for t in data.get("tasks", [])
-        if t.get("cross_sprint_parent") == task.get("id")
-    }
-    own = task.get("sprint_id")
-    for binding in task_sprint_bindings(task):
-        sprint_id = binding.get("sprint_id")
-        if sprint_id and sprint_id != own:
-            ids.add(sprint_id)
-    return ids
 
 
 def task_uploaded_mins(task: dict) -> float:
@@ -1400,6 +1393,99 @@ def task_current_issue(task: dict, data: dict = None) -> str | None:
     return task.get("github_issue")
 
 
+def current_binding(task: dict, data: dict = None) -> dict | None:
+    """The binding object :func:`task_current_issue` reads from, or None.
+
+    Same resolution order as ``task_current_issue`` (current-sprint binding →
+    latest by sprint ``start_date`` → last in insertion order) but returns the
+    live dict so a writer can update it in place. Offline; never a network call.
+    Returns None when the task has no ``sprint_issues`` entries at all.
+    """
+    bindings = task.get("sprint_issues")
+    if not isinstance(bindings, list) or not bindings:
+        return None
+    sprints = get_cached_sprints(data) if data is not None else []
+    if sprints:
+        current = find_sprint_for_date(sprints, datetime.now().date())
+        if current:
+            b = next((x for x in bindings if x.get("sprint_id") == current["id"]), None)
+            if b is not None:
+                return b
+        # sorted() returns the same dict objects, so this is still a live binding.
+        return task_sprint_bindings(task, sprints)[-1]
+    return bindings[-1]
+
+
+def task_issue_refs(task: dict) -> list[str]:
+    """Every distinct issue ref the task is bound to, oldest binding first.
+
+    Includes the legacy ``github_issue`` if it isn't already on a binding, so
+    this is safe on un-migrated data.
+    """
+    out: list[str] = []
+    for b in task_sprint_bindings(task):
+        ref = b.get("issue")
+        if ref and ref not in out:
+            out.append(ref)
+    legacy = task.get("github_issue")
+    if legacy and legacy not in out:
+        out.append(legacy)
+    return out
+
+
+def set_task_current_issue(task: dict, issue_ref: str, data: dict = None) -> dict:
+    """Point the task's current binding at *issue_ref*. Returns that binding.
+
+    Target binding, in order: the one for the task's own ``sprint_id``, else the
+    one :func:`current_binding` resolves (only if it is unclaimed or already
+    holds *issue_ref*), else a freshly appended binding for the task's sprint.
+
+    The legacy ``task["github_issue"]`` key is written **as well**. That is
+    deliberate for Phase 3: ``tracker.py`` and ``mcp_server.py`` (and an older
+    wt.py on the other Mac reading the iCloud-synced file) still read the flat
+    key directly, so dropping the mirror here would break them. Phase 3 stops
+    *reading* it in wt.py; a later phase can stop writing it once every consumer
+    goes through ``task_current_issue()``.
+    """
+    bindings = _ensure_bindings(task)
+    own = task.get("sprint_id")
+    binding = _find_binding(bindings, sprint_id=own) if own else None
+    if binding is None:
+        candidate = current_binding(task, data)
+        if candidate is not None and candidate.get("issue") in (None, issue_ref):
+            binding = candidate
+    if binding is None:
+        binding = {
+            "sprint_id": own,
+            "sprint": task.get("sprint"),
+            "issue": None,
+            "state": "closed" if task.get("status") == "done" else "open",
+            "hours_synced": None,
+            "synced_at": None,
+            "created_at": time.time(),
+        }
+        bindings.append(binding)
+    binding["issue"] = issue_ref
+    task["github_issue"] = issue_ref  # legacy mirror — see docstring
+    return binding
+
+
+def clear_task_current_issue(task: dict, data: dict = None) -> str | None:
+    """Unlink the task's current issue. Returns the ref that was removed.
+
+    Clears it from whichever binding(s) hold it and drops the legacy
+    ``github_issue`` key. The binding itself is kept (bindings are never
+    deleted — plan §2.3 step 6), it just no longer names an issue.
+    """
+    old = task_current_issue(task, data)
+    if old:
+        for b in task.get("sprint_issues") or []:
+            if b.get("issue") == old:
+                b["issue"] = None
+    task.pop("github_issue", None)
+    return old
+
+
 def task_start_sprint(task: dict, sprints: list[dict]) -> dict | None:
     """The sprint this task started in.
 
@@ -1441,6 +1527,38 @@ def task_mins_for_sprint(task: dict, sprint_id: str, sprints: list[dict]) -> flo
     return total
 
 
+def task_reportable_mins(task: dict, sprints: list[dict], sprint_id: str = None) -> float:
+    """Minutes to report to GitHub for the task's current sprint context.
+
+    Replacement for ``task_logged_mins_for_sprint`` on every GitHub-hours path.
+    Resolution order for the sprint:
+
+      1. *sprint_id* when given (e.g. the binding being synced).
+      2. The sprint of the task's current binding (:func:`current_binding`).
+      3. The task's legacy ``sprint_id``.
+
+    Once a sprint is resolved the value is ``task_mins_for_sprint`` — no
+    "unknown sprint → whole task total" fallback, which is what over-reported
+    for cross-sprint tasks. The total is only used when **no** sprint can be
+    resolved at all (no sprint list, or none of the above resolves), because in
+    that case reporting 0.0 would silently *under*-report and is strictly worse
+    than today's behaviour.
+    """
+    sprints = sprints or []
+    if not sprints:
+        return task_logged_mins(task)
+    known = {s.get("id") for s in sprints}
+    candidates = [sprint_id]
+    binding = current_binding(task)
+    if binding is not None:
+        candidates.append(binding.get("sprint_id"))
+    candidates.append(task.get("sprint_id"))
+    for sid in candidates:
+        if sid and sid in known:
+            return task_mins_for_sprint(task, sid, sprints)
+    return task_logged_mins(task)
+
+
 def logs_in_date_range(
     data: dict,
     start_date,
@@ -1450,9 +1568,13 @@ def logs_in_date_range(
     """Return [(task, log), ...] for every log whose effective date falls in
     the inclusive range ``[start_date, end_date]``.
 
-    Sorted by effective timestamp ascending. Shadow tasks (with
-    ``cross_sprint_parent``) are skipped because their logs duplicate the
-    original task's logs. Done tasks are included.
+    Sorted by effective timestamp ascending. Done tasks are included.
+
+    Every task in ``data["tasks"]`` is now a distinct unit of work, so there is
+    nothing to filter out: the old ``cross_sprint_parent`` shadow-skip is gone
+    because ``load()`` guarantees shadows do not exist (they are converted into
+    ``sprint_issues`` bindings by ``_migrate_shadows_to_bindings``, which also
+    strips any an older wt.py re-introduces via iCloud).
 
     Args:
         data: The full data dict from ``load()``.
@@ -1463,8 +1585,6 @@ def logs_in_date_range(
     """
     out: list[tuple[dict, dict]] = []
     for task in data.get("tasks", []):
-        if task.get("cross_sprint_parent"):
-            continue
         if role_id is not None and task.get("role_id") != role_id:
             continue
         for log in task.get("logs", []):
@@ -1835,6 +1955,19 @@ def _reconcile_plan(task: dict, data: dict, sprints: list[dict], *,
         minutes = targets[sid]
         hours = mins_to_quarter_hours(minutes) if minutes > 0 else 0.0
         will_close = bool(close_past and ended(sid))
+        if repo and not create_issues:
+            # Don't bind the sprint at all: an issue-less binding would count as
+            # "already bound" on the next pass, so a later run with
+            # create_issues=True could never mint the issue this sprint needs.
+            # Report it instead, so `wt sync-sprints --all` (which defaults to
+            # create_issues=False) can tell the user exactly what it skipped.
+            plan["skipped"].append({
+                "sprint": sprint_title, "sprint_id": sid, "issue": None,
+                "minutes": minutes, "hours": hours,
+                "needs_issue": True, "repo": repo,
+                "reason": "would need a new issue (create_issues=False)",
+            })
+            continue
         # A past-sprint issue keeps today's " (Sprint N)" title suffix. Only a
         # task that has no issue at all gets a plain-titled one, and only for
         # its most recent sprint — matching create_github_issue()'s use in
@@ -1941,10 +2074,11 @@ def _reconcile_plan(task: dict, data: dict, sprints: list[dict], *,
         })
 
     # Local-only: keep the legacy sprint/sprint_id pointing at whichever sprint
-    # the task's carried-forward "current" issue ends up bound to. Phase 3
-    # retires these fields; until then wt sprint, the TUI board and
-    # task_logged_mins_for_sprint() all read them. Listed as an op so an empty
-    # plan really means "nothing to do".
+    # the task's carried-forward "current" issue ends up bound to. wt.py no longer
+    # reads them for hours (task_reportable_mins goes through the bindings), but
+    # the TUI board, mcp_server.py and an older wt.py on the other Mac still do,
+    # so they stay in sync. Listed as an op so an empty plan really means
+    # "nothing to do".
     anchor = carry["sprint_id"] if (carry and carry["sprint_id"] in by_id) else latest
     if anchor and task.get("sprint_id") != anchor:
         own_start = by_id[own]["start_date"] if own in by_id else None
@@ -1980,7 +2114,11 @@ def reconcile_task_sprints(task: dict, data: dict, sprints: list[dict], *,
       2. Target set = {sprints with time} ∪ {current sprint, if the task is
          open}. The second term replaces the marker-log ritual (plan §1.3).
       3. Target sprints with no binding get one, plus a GitHub issue when the
-         task has a ``github_repo`` and *create_issues* is set.
+         task has a ``github_repo``. With ``create_issues=False`` a sprint that
+         *would* need a new issue is reported in ``skipped`` (flagged
+         ``needs_issue``) and left unbound, rather than getting an issue-less
+         binding that a later ``create_issues=True`` run would mistake for
+         "already handled".
       4. Every binding's hours are recomputed from the logs and pushed only
          when they differ from the cached ``hours_synced``.
       5. Bindings whose sprint has ended get Status=Done + a closed issue.
@@ -2236,16 +2374,23 @@ def split_cross_sprint_task(task: dict, data: dict, save_callback,
                             progress_callback=None) -> dict:
     """**Deprecated** — thin wrapper over :func:`reconcile_task_sprints`.
 
-    Kept so ``tracker.py``, ``mcp_server.py`` and ``cmd_split_sprint`` keep
-    working unchanged through Phase 2; Phase 3 migrates them to call reconcile
-    directly. The historical gate ("only has time in one sprint" → error) and
-    the return-dict keys ``success`` / ``sprint_tasks_created`` / ``main_sprint``
-    / ``error`` are preserved.
+    Kept so ``tracker.py`` and ``mcp_server.py`` keep importing cleanly while
+    they are migrated to call reconcile directly. ``wt.py`` no longer calls it:
+    ``close_task`` reconciles directly and the CLI entry point is now
+    ``wt sync-sprints`` (:func:`cmd_sync_sprints`). The return-dict keys
+    ``success`` / ``sprint_tasks_created`` / ``main_sprint`` / ``error`` and the
+    "only has time in one sprint" gate are preserved.
 
     What changed underneath: previous sprints are recorded as ``sprint_issues``
     bindings on the task instead of duplicate "shadow" task objects. The GitHub
     side is unchanged — one issue per sprint, past ones titled
     ``Task (Sprint N)``, closed, carrying that sprint's hours.
+
+    Phase-3 gate change: the "one sprint" test now uses
+    :func:`task_sprints_with_time` (sprints with **>0** minutes) instead of
+    ``sprint_summary_for_task`` (which counted zero-minute sprints). A task whose
+    only second sprint is a 0-minute "rollover marker" log therefore now reports
+    "only has time in one sprint" rather than performing a no-op split.
     """
     def progress(msg):
         if progress_callback:
@@ -2265,8 +2410,7 @@ def split_cross_sprint_task(task: dict, data: dict, save_callback,
         result["error"] = "No sprints found"
         return result
 
-    summary = sprint_summary_for_task(task, all_sprints)
-    if len(summary) <= 1:
+    if len(task_sprints_with_time(task, all_sprints)) <= 1:
         result["error"] = "Task only has time in one sprint"
         return result
 
@@ -2642,8 +2786,8 @@ def setup_issue_in_project(issue_ref: str, task: dict, data: dict) -> dict:
                 if not update_project_sprint(issue_ref, current_sprint["id"], current_sprint["field_id"], data, project_info=pi, item_id=item_id):
                     result["errors"].append(f"Failed to set sprint: {current_sprint['title']}")
 
-        # Set hours (filtered by task's sprint if assigned, rounded to 0.25 hours)
-        sprint_mins = task_logged_mins_for_sprint(task, all_sprints)
+        # Set hours (filtered by the task's current sprint, rounded to 0.25h)
+        sprint_mins = task_reportable_mins(task, all_sprints)
         if sprint_mins > 0:
             hours = mins_to_quarter_hours(sprint_mins)
             if not update_project_hours(issue_ref, hours, data, project_info=pi, item_id=item_id):
@@ -2703,8 +2847,8 @@ def sync_project_hours(issue_ref: str, task: dict, data: dict, save_callback=Non
         if field_id:
             update_project_sprint(issue_ref, sprint_id, field_id, data)
 
-    # Sync hours (filtered by task's sprint if assigned)
-    sprint_mins = task_logged_mins_for_sprint(task, all_sprints)
+    # Sync hours (filtered by the task's current sprint)
+    sprint_mins = task_reportable_mins(task, all_sprints)
     if sprint_mins > 0:
         hours = mins_to_quarter_hours(sprint_mins)
         if update_project_hours(issue_ref, hours, data):
@@ -2779,6 +2923,34 @@ def update_issue_title(issue_ref: str, new_title: str) -> bool:
     return result.returncode == 0
 
 
+def _legacy_split_result(rec: dict, task: dict) -> dict:
+    """Render a reconcile result in the shape ``split_cross_sprint_task`` returned.
+
+    ``close_task()["split_result"]`` used to be a split result dict; renderers
+    (``wt done``, the TUI, MCP) read ``sprint_tasks_created`` and ``main_sprint``
+    off it. Phase 3 puts the full reconcile result there instead, but keeps those
+    two keys populated so nothing downstream breaks mid-refactor.
+    """
+    created = [
+        {"sprint": e["sprint"], "total_mins": e.get("minutes", 0),
+         "issue_ref": e.get("issue")}
+        for e in rec.get("created", [])
+    ]
+    for e in rec.get("skipped", []):
+        if e.get("reason") == "already bound":
+            created.append({"sprint": e.get("sprint"), "total_mins": e.get("minutes", 0),
+                            "issue_ref": e.get("issue"), "skipped": "already bound"})
+    for e in rec.get("errors", []):
+        created.append({"sprint": e.get("sprint"), "total_mins": e.get("minutes", 0),
+                        "issue_ref": e.get("issue"), "error": e["error"]})
+    out = dict(rec)
+    out["sprint_tasks_created"] = created
+    out["main_sprint"] = task.get("sprint") or (
+        rec["target"][-1]["sprint"] if rec.get("target") else None
+    )
+    return out
+
+
 def close_task(task: dict, data: dict, save_callback, prompt_callback=None, comment_callback=None) -> dict:
     """
     Full task closing workflow.
@@ -2791,7 +2963,28 @@ def close_task(task: dict, data: dict, save_callback, prompt_callback=None, comm
         comment_callback: Optional function(msg) -> str|None to get closing comment from user
 
     Returns:
-        Dict with results: {success, issue_created, issue_closed, project_updated, skipped_github, comment_added, error}
+        Dict with results: {success, issue_created, issue_closed, project_updated,
+        skipped_github, comment_added, split_performed, split_result,
+        reconcile_result, error}
+
+    Phase 3: step 2.5 now calls :func:`reconcile_task_sprints` directly instead of
+    going through the deprecated ``split_cross_sprint_task`` wrapper. Two
+    consequences worth knowing:
+
+      * The old gate was ``len(sprint_summary_for_task(task, sprints)) > 1``,
+        which counted **zero-minute** sprints — so a task carrying one of the
+        0-minute "rollover marker" logs (plan §1.3) looked multi-sprint and got
+        split, while an identical task without the marker did not. Reconcile is
+        idempotent and plans nothing when there is nothing to do, so it is now
+        called unconditionally and the gate is gone. ``split_performed`` reports
+        whether the reconcile actually created or re-pointed a binding.
+      * Hours reported to the current issue come from
+        :func:`task_reportable_mins`, i.e. the *current binding's* sprint rather
+        than the task's mutable ``sprint_id``.
+
+    ``recurrent`` tasks still skip the reconcile entirely: they intentionally span
+    sprints and are handled by ``close-recurrent`` / ``new-recurrent`` (plan
+    Phase 5 unifies them; out of scope here).
     """
     result = {
         "success": False,
@@ -2802,6 +2995,7 @@ def close_task(task: dict, data: dict, save_callback, prompt_callback=None, comm
         "comment_added": False,
         "split_performed": False,
         "split_result": None,
+        "reconcile_result": None,
         "error": None
     }
 
@@ -2817,7 +3011,8 @@ def close_task(task: dict, data: dict, save_callback, prompt_callback=None, comm
         return result
 
     # 2. Ensure GitHub issue exists
-    if not task.get("github_issue"):
+    issue_ref = task_current_issue(task, data)
+    if not issue_ref:
         if prompt_callback:
             create = prompt_callback(
                 f"Task '{task['title']}' has no GitHub issue. Create one in {repo}?"
@@ -2828,46 +3023,50 @@ def close_task(task: dict, data: dict, save_callback, prompt_callback=None, comm
 
         try:
             issue_ref = create_github_issue(task, repo)
-            task["github_issue"] = issue_ref
+            set_task_current_issue(task, issue_ref, data)
             result["issue_created"] = True
             save_callback(data)
         except Exception as e:
             result["error"] = f"Failed to create issue: {e}"
             return result
 
-    # 2.5. If the task spans multiple sprints, split it first so each sprint's
-    # hours land on their own (shadow) issue. The split re-points this task to
-    # its most recent sprint with only that sprint's hours, which keeps the
-    # project-hours sync below from over-reporting. Shadow tasks (already split,
-    # carry cross_sprint_parent) must never re-split, and recurrent tasks
-    # intentionally span sprints so they are excluded from cross-sprint splitting.
+    # 2.5. Reconcile the task's per-sprint bindings against its logs, so each
+    # past sprint's hours land on their own issue and the current issue only ever
+    # carries its own sprint's hours (Option A, plan §2.4). Idempotent, so this
+    # is unconditional — see the docstring for what replaced the old gate.
     all_sprints = get_all_sprints(data)
-    if not task.get("cross_sprint_parent") and task.get("status") != "recurrent":
-        summary = sprint_summary_for_task(task, all_sprints)
-        if len(summary) > 1:
-            split_res = split_cross_sprint_task(task, data, save_callback, all_sprints)
-            result["split_performed"] = True
-            result["split_result"] = split_res
-            if not split_res.get("success"):
-                result["error"] = f"Cross-sprint split failed: {split_res.get('error')}"
-                return result
+    if all_sprints and task.get("status") != "recurrent":
+        rec = reconcile_task_sprints(task, data, all_sprints,
+                                     save_callback=save_callback)
+        result["reconcile_result"] = rec
+        result["split_result"] = _legacy_split_result(rec, task)
+        result["split_performed"] = bool(rec.get("created") or rec.get("repointed"))
+        if not rec.get("success"):
+            detail = rec.get("error") or "; ".join(
+                f"{e.get('sprint')}: {e['error']}" for e in rec.get("errors", [])
+            ) or "unknown error"
+            result["error"] = f"Sprint reconcile failed: {detail}"
+            return result
+        # A create op can adopt the legacy field; re-read so we close the right one.
+        issue_ref = task_current_issue(task, data) or issue_ref
+
+    binding = _find_binding(task.get("sprint_issues") or [], issue=issue_ref)
 
     # 3. Add to project and update fields
     config = data.get("config", {})
     if config.get("github_project_number"):
         try:
-            # Report only the assigned sprint's hours. A cross-sprint task keeps
-            # all logs locally (source of truth) but its per-sprint hours live on
-            # the shadow tasks' issues; reporting total here would double-count.
-            sprint_mins = task_logged_mins_for_sprint(task, all_sprints)
+            # Report only the current binding's sprint hours. The task keeps all
+            # logs locally (source of truth) while each past sprint's hours live
+            # on its own binding's issue; reporting the total would double-count.
+            sprint_id = (binding or {}).get("sprint_id") or task.get("sprint_id")
+            sprint_mins = task_reportable_mins(task, all_sprints, sprint_id)
             hours = mins_to_quarter_hours(sprint_mins)
-            add_to_project_and_update(task["github_issue"], hours, data)
+            add_to_project_and_update(issue_ref, hours, data)
             result["project_updated"] = True
 
             # Record what GitHub was told on the matching binding, so a later
             # reconcile doesn't re-push an identical value.
-            binding = _find_binding(task.get("sprint_issues") or [],
-                                    issue=task["github_issue"])
             if binding is not None:
                 binding["hours_synced"] = hours
                 binding["synced_at"] = time.time()
@@ -2875,39 +3074,37 @@ def close_task(task: dict, data: dict, save_callback, prompt_callback=None, comm
             # Set activity if the task has one
             activity = get_task_activity(task)
             if activity:
-                update_project_activity(task["github_issue"], activity, data)
+                update_project_activity(issue_ref, activity, data)
 
-            # Set sprint from task's stored sprint
-            sprint_id = task.get("sprint_id")
+            # Set the Sprint field from the binding we are closing
             if sprint_id:
                 field_id = all_sprints[0]["field_id"] if all_sprints else None
                 if field_id:
-                    update_project_sprint(task["github_issue"], sprint_id, field_id, data)
+                    update_project_sprint(issue_ref, sprint_id, field_id, data)
 
             # Set type if the task has one
             type_val = get_task_type(task)
             if type_val:
-                update_project_type(task["github_issue"], type_val, data)
+                update_project_type(issue_ref, type_val, data)
         except Exception as e:
             # Project update is non-fatal - still mark task as done
             result["error"] = f"Project update failed: {e}"
 
     # 4. Check for comments and prompt for closing comment if none
-    if comment_callback and not issue_has_comments(task["github_issue"]):
+    if comment_callback and not issue_has_comments(issue_ref):
         comment = comment_callback(
-            f"Issue {task['github_issue']} has no comments. Add a closing comment?"
+            f"Issue {issue_ref} has no comments. Add a closing comment?"
         )
         if comment:
-            if add_issue_comment(task["github_issue"], comment):
+            if add_issue_comment(issue_ref, comment):
                 result["comment_added"] = True
 
-    # 5. Close the GitHub issue
-    if close_github_issue(task["github_issue"]):
+    # 5. Close the GitHub issue — only the current binding's. Past-sprint
+    #    bindings were already closed by the reconcile above.
+    if close_github_issue(issue_ref):
         result["issue_closed"] = True
         # Keep the binding's cached state honest, or a reconcile run after this
         # sprint ends would try to close an already-closed issue.
-        binding = _find_binding(task.get("sprint_issues") or [],
-                                issue=task["github_issue"])
         if binding is not None:
             binding["state"] = "closed"
 
@@ -2924,9 +3121,12 @@ def find_recurrent_tasks_to_close(data: dict, all_previous: bool = False) -> lis
 
     A task qualifies when all of the following hold:
       - ``status == "recurrent"``
-      - it has a linked ``github_issue`` (tasks without one are excluded)
-      - it is not a cross-sprint shadow task (``cross_sprint_parent`` unset)
+      - it has a linked issue (via ``task_current_issue``; tasks without one are
+        excluded)
       - its ``sprint_id`` matches one of the target sprints
+
+    (The old "not a cross-sprint shadow" condition is gone — ``load()``
+    guarantees shadow tasks no longer exist.)
 
     Target sprints:
       - By default, only the sprint immediately preceding the current one.
@@ -2957,9 +3157,7 @@ def find_recurrent_tasks_to_close(data: dict, all_previous: bool = False) -> lis
     for t in data.get("tasks", []):
         if t.get("status") != "recurrent":
             continue
-        if not t.get("github_issue"):
-            continue
-        if t.get("cross_sprint_parent"):
+        if not task_current_issue(t, data):
             continue
         sprint_id = t.get("sprint_id")
         if not sprint_id or sprint_id not in target_ids:
@@ -3004,7 +3202,7 @@ def close_previous_sprint_recurrent_tasks(data: dict, save_callback, all_previou
             "task_id": task["id"],
             "title": task["title"],
             "sprint": task.get("sprint"),
-            "issue": task.get("github_issue"),
+            "issue": task_current_issue(task, data),
             "success": False,
             "issue_closed": False,
             "project_updated": False,
@@ -3097,8 +3295,9 @@ def find_recurrent_tasks_to_recreate(data: dict, all_previous: bool = False) -> 
     if not source_ids:
         return []
 
-    # Exclude cross-sprint shadow tasks throughout.
-    tasks = [t for t in data.get("tasks", []) if not t.get("cross_sprint_parent")]
+    # (Phase 3: the cross-sprint shadow exclusion that used to sit here is gone —
+    # load() guarantees shadow task objects no longer exist.)
+    tasks = data.get("tasks", [])
 
     # Base names of active recurring series (any task currently 'recurrent').
     recurring_bases = {
@@ -3220,7 +3419,7 @@ def create_current_sprint_recurrent_tasks(data: dict, save_callback, all_previou
 
         try:
             issue_ref = create_github_issue(task, repo)
-            task["github_issue"] = issue_ref
+            set_task_current_issue(task, issue_ref, data)
             save_callback(data)
             outcome["issue"] = issue_ref
             outcome["issue_created"] = True
@@ -3362,7 +3561,7 @@ def cmd_add(args):
         except Exception as e:
             print(c(f"  Failed to create issue: {e}", "red"))
             sys.exit(1)
-        task["github_issue"] = issue_ref
+        set_task_current_issue(task, issue_ref, data)
         save(data)
         print(c(f"  ✓ Created issue: {issue_ref}", "green"))
 
@@ -3385,15 +3584,12 @@ def cmd_list(args):
 
     filter_role = None
     show_done = False
-    show_shadows = False
     i = 0
     while i < len(args):
         if args[i] == "--role" and i + 1 < len(args):
             filter_role = resolve_role(data, args[i+1]); i += 2
         elif args[i] in ("--all", "-a"):
             show_done = True; i += 1
-        elif args[i] == "--shadows":
-            show_shadows = True; i += 1
         else:
             i += 1
 
@@ -3404,9 +3600,8 @@ def cmd_list(args):
     if not show_done:
         tasks = [t for t in tasks if t.get("status") != "done"]
 
-    # Hide shadow tasks (cross-sprint splits) by default
-    if not show_shadows:
-        tasks = [t for t in tasks if not t.get("cross_sprint_parent")]
+    # (Phase 3: the `--shadows` flag and its cross_sprint_parent filter are gone —
+    # every task object is a real unit of work now.)
 
     if not tasks:
         print(c("No tasks.", "dim")); return
@@ -3427,7 +3622,7 @@ def cmd_list(args):
             status = STATUS_LABELS.get(t.get("status", "todo"), "")
             dot = c("▶ ", "green") if running else "  "
             # Notes indicator: # for GitHub issue, + for local notes
-            if t.get("github_issue"):
+            if task_current_issue(t, data):
                 notes_icon = c("#", "cyan")
             elif has_notes(t["id"]):
                 notes_icon = c("+", "dim")
@@ -3894,27 +4089,28 @@ def cmd_done(args):
         if result["skipped_github"]:
             print(c(f"  (No GitHub integration — task has no repo)", "dim"))
         else:
-            if result.get("split_performed"):
-                sr = result.get("split_result") or {}
-                for st in sr.get("sprint_tasks_created", []):
-                    if st.get("skipped"):
-                        print(c(f"  Split: {st['sprint']} → skipped ({st['skipped']})", "dim"))
-                        continue
-                    issue = st.get("issue_ref") or "no issue"
-                    print(c(f"  Split: {st['sprint']} → {fmt_mins(st['total_mins'])} ({issue})", "dim"))
-                if sr.get("main_sprint"):
-                    print(c(f"  Main task kept on {sr['main_sprint']}", "dim"))
+            issue_ref = task_current_issue(task, data)
+            rec = result.get("reconcile_result")
+            if rec:
+                for line in _reconcile_outcome_lines(rec):
+                    print(c(f"  {line}", "dim"))
             if result["issue_created"]:
-                print(c(f"  Created issue: {task['github_issue']}", "dim"))
+                print(c(f"  Created issue: {issue_ref}", "dim"))
             if result.get("comment_added"):
                 print(c(f"  Added closing comment", "dim"))
             if result["issue_closed"]:
-                print(c(f"  Closed issue: {task['github_issue']}", "dim"))
+                print(c(f"  Closed issue: {issue_ref}", "dim"))
             if result["project_updated"]:
-                # Report the sprint-filtered hours actually synced (a cross-sprint
-                # task keeps all logs locally but only reports its current sprint).
-                synced = mins_to_quarter_hours(task_logged_mins_for_sprint(task, get_all_sprints(data)))
-                print(c(f"  Updated project (Status: Done, Hours: {synced})", "dim"))
+                # Report the sprint-filtered hours actually synced: the task keeps
+                # every log locally, but each past sprint's hours live on its own
+                # binding's issue, so only the current binding's total goes here.
+                binding = _find_binding(task.get("sprint_issues") or [], issue=issue_ref)
+                sprints = get_all_sprints(data)
+                synced = mins_to_quarter_hours(task_reportable_mins(
+                    task, sprints, (binding or {}).get("sprint_id")))
+                sprint_label = (binding or {}).get("sprint") or task.get("sprint") or "?"
+                print(c(f"  Updated project (Status: Done, Sprint: {sprint_label}, "
+                        f"Hours: {synced})", "dim"))
             elif result.get("error"):
                 print(c(f"  Warning: {result['error']}", "yellow"))
     else:
@@ -3959,7 +4155,7 @@ def cmd_close_recurrent(args):
     if dry_run:
         print(c(f"Would close {len(tasks)} recurrent task(s) from {scope}:", "yellow"))
         for t in tasks:
-            print(f"  • {t['title']}  [{t.get('sprint', '?')}]  {t.get('github_issue')}")
+            print(f"  • {t['title']}  [{t.get('sprint', '?')}]  {task_current_issue(t, data)}")
         return
 
     print(c(f"Closing {len(tasks)} recurrent task(s) from {scope}...", "cyan"))
@@ -4031,7 +4227,10 @@ def cmd_delete(args):
         print("Usage: wt delete <task-id or title>"); sys.exit(1)
     data = load()
     task = resolve_task(data, " ".join(args))
-    issue_ref = task.get("github_issue")
+    issue_ref = task_current_issue(task, data)
+    # Past-sprint bindings are separate, already-closed issues; deleting them is
+    # not what `wt delete` ever did, so name them instead of silently orphaning.
+    other_issues = [r for r in task_issue_refs(task) if r != issue_ref]
     data["tasks"] = [t for t in data["tasks"] if t["id"] != task["id"]]
     if (data.get("active_timer") or {}).get("task_id") == task["id"]:
         data["active_timer"] = None
@@ -4042,6 +4241,9 @@ def cmd_delete(args):
             print(c(f"  Deleted GitHub issue: {issue_ref}", "dim"))
         else:
             print(c(f"  Warning: Failed to delete GitHub issue {issue_ref} (may need admin permissions)", "yellow"))
+    if other_issues:
+        print(c(f"  Note: {len(other_issues)} past-sprint issue(s) left in place: "
+                + ", ".join(other_issues), "yellow"))
 
 
 def cmd_rename(args):
@@ -4060,10 +4262,13 @@ def cmd_rename(args):
     print(c(f"✓ Renamed: {old_title}", "dim"))
     print(c(f"       → {new_title}", "green"))
 
-    # Update linked GitHub issue title if present
-    if task.get("github_issue"):
-        if update_issue_title(task["github_issue"], new_title):
-            print(c(f"  Updated GitHub issue: {task['github_issue']}", "dim"))
+    # Update the current binding's GitHub issue title if present. Past-sprint
+    # issues keep their " (Sprint N)" titles — renaming those is not this
+    # command's job (and would need the suffix re-applied per binding).
+    issue_ref = task_current_issue(task, data)
+    if issue_ref:
+        if update_issue_title(issue_ref, new_title):
+            print(c(f"  Updated GitHub issue: {issue_ref}", "dim"))
         else:
             print(c(f"  Warning: Failed to update GitHub issue title", "yellow"))
 
@@ -4104,8 +4309,8 @@ def cmd_notes(args):
     task = resolve_task(data, " ".join(args))
 
     # Check if task is linked to a GitHub issue
-    if task.get("github_issue"):
-        gh_ref = task["github_issue"]
+    gh_ref = task_current_issue(task, data)
+    if gh_ref:
         print(c(f"Opening GitHub issue: {gh_ref}", "cyan"))
         subprocess.run(["gh", "issue", "view", *gh_issue_args(gh_ref), "--web"])
         return
@@ -4204,14 +4409,14 @@ def cmd_push(args):
     if not task:
         print(c(f"No task matching '{query}'", "red"))
         sys.exit(1)
-    issue_ref = task.get("github_issue")
+    issue_ref = task_current_issue(task, data)
     if not issue_ref:
         print(c(f"Task '{task['title']}' has no linked GitHub issue", "red"))
         sys.exit(1)
     result = setup_issue_in_project(issue_ref, task, data)
     save(data)  # persist mark_logs_uploaded side-effect
     if result["success"]:
-        hours = mins_to_quarter_hours(task_logged_mins_for_sprint(task, get_all_sprints(data)))
+        hours = mins_to_quarter_hours(task_reportable_mins(task, get_all_sprints(data)))
         print(c(f"Pushed '{task['title']}' to {issue_ref}: {hours}h", "green"))
     else:
         print(c(f"Push completed with errors: {', '.join(result['errors'])}", "yellow"))
@@ -4256,8 +4461,8 @@ def cmd_link(args):
     # Ensure current user is assigned to the issue
     ensure_issue_assigned(issue_ref)
 
-    # Store the issue reference (normalized form)
-    task["github_issue"] = issue_ref
+    # Store the issue reference (normalized form) on the current binding
+    set_task_current_issue(task, issue_ref, data)
     # Pin the task's repo from the issue ref (so the close workflow engages)
     if not task.get("github_repo") and "#" in issue_ref:
         task["github_repo"] = issue_ref.split("#", 1)[0]
@@ -4273,14 +4478,17 @@ def cmd_unlink(args):
     data = load()
     task = resolve_task(data, " ".join(args))
 
-    if not task.get("github_issue"):
+    if not task_current_issue(task, data):
         print(c(f"Task '{task['title']}' is not linked to a GitHub issue.", "yellow"))
         sys.exit(0)
 
-    old_issue = task["github_issue"]
-    del task["github_issue"]
+    old_issue = clear_task_current_issue(task, data)
     save(data)
     print(c(f"Unlinked '{task['title']}' from {old_issue}", "green"))
+    remaining = task_issue_refs(task)
+    if remaining:
+        print(c(f"  Still bound to {len(remaining)} past-sprint issue(s): "
+                + ", ".join(remaining), "dim"))
 
 
 def cmd_config(args):
@@ -4433,9 +4641,10 @@ def create_task_from_issue(
         return {"task": None, "error": f"Could not find GitHub issue: {issue_ref}", "existed": False}
     issue_info = json.loads(result.stdout)
 
-    # Don't create a duplicate if a task is already linked to this issue.
+    # Don't create a duplicate if a task is already linked to this issue — check
+    # every binding, not just the legacy field, so a past-sprint issue matches too.
     for t in data["tasks"]:
-        if t.get("github_issue") == issue_ref:
+        if issue_ref in task_issue_refs(t):
             return {"task": t, "error": None, "existed": True}
 
     task = {
@@ -4463,6 +4672,10 @@ def create_task_from_issue(
                 task["sprint_id"] = current_sprint["id"]
         except Exception:
             pass
+
+    # Record the link as a binding too (set after the sprint so the binding lands
+    # on the right sprint). Rewrites the same legacy key it was seeded with.
+    set_task_current_issue(task, issue_ref, data)
 
     data["tasks"].insert(0, task)
     return {"task": task, "error": None, "existed": False}
@@ -4597,7 +4810,7 @@ def cmd_add_issue(args):
     print(c(f"✓ Created: {task['title']}", "green"))
     print(f"  [{roles.get(role_id, role_id)}] [{STATUS_LABELS.get(task['status'], task['status'])}]")
     print(c(f"  id: {task['id']}", "dim"))
-    print(c(f"  GitHub: {task['github_issue']}", "cyan"))
+    print(c(f"  GitHub: {task_current_issue(task, data)}", "cyan"))
     if task.get("local_folder"):
         print(c(f"  Folder: {task['local_folder']}", "dim"))
 
@@ -5869,52 +6082,130 @@ def cmd_report(args):
     print(format_time_report(payload, use_color=True))
 
 
+def _sprints_for_cli(data: dict) -> tuple[list[dict], bool]:
+    """Sprint list for a CLI command, preferring the live fetch.
+
+    Returns ``(sprints, from_cache)``. Falling back to
+    ``config.sprints_cache`` keeps ``wt sprint`` / ``wt sync-sprints`` usable
+    with no network; both key sets are the same date-object contract, unlike the
+    camelCase ``startDate``/``duration`` that only the live fetch emits.
+    """
+    live = get_all_sprints(data)
+    if live:
+        return live, False
+    return get_cached_sprints(data), True
+
+
+def _task_group_sprint(task: dict, sprints: list[dict], current: dict | None) -> dict | None:
+    """Which sprint *task* should be listed under in ``wt sprint``.
+
+    The current sprint when the task has a binding there, else the task's newest
+    resolvable binding, else its legacy ``sprint_id``. None → "Unassigned".
+    """
+    by_id = {s["id"]: s for s in sprints if s.get("id")}
+    bindings = task_sprint_bindings(task, sprints)
+    if current and any(b.get("sprint_id") == current["id"] for b in bindings):
+        return current
+    for b in reversed(bindings):
+        s = by_id.get(b.get("sprint_id"))
+        if s:
+            return s
+    return by_id.get(task.get("sprint_id"))
+
+
 def cmd_sprint(args):
-    """Show current sprint info and tasks grouped by sprint."""
+    """Show current sprint info and active tasks grouped by their sprint bindings."""
     data = load()
-    all_sprints = get_all_sprints(data)
-    current = get_current_sprint(data)
+    all_sprints, from_cache = _sprints_for_cli(data)
+    today = datetime.now().date()
+    current = find_sprint_for_date(all_sprints, today) if all_sprints else None
+
+    if not all_sprints:
+        print(c("\n  No sprints found (project not configured or query failed).", "yellow"))
+        return
+    if from_cache:
+        print(c("\n  (offline — using the persisted sprints cache)", "dim"))
 
     if current:
         print(c(f"\n  Current sprint: {current['title']}", "bold", "cyan"))
-        print(c(f"  Start: {current['startDate']}, Duration: {current['duration']} days", "dim"))
-    elif all_sprints:
-        print(c("\n  No active sprint right now.", "yellow"))
+        # Read start_date/end_date (date objects), which both get_all_sprints()
+        # and get_cached_sprints() provide. The old code read current["startDate"]
+        # and current["duration"] — camelCase keys only the live fetch emits — so
+        # a cache-backed sprint dict raised KeyError here (plan §1.7 neighbour).
+        last_day = current["end_date"] - timedelta(days=1)
+        days = (current["end_date"] - current["start_date"]).days
+        print(c(f"  {current['start_date']} → {last_day}  ({days} days)", "dim"))
     else:
-        print(c("\n  No sprints found (project not configured or query failed).", "yellow"))
-        return
+        print(c("\n  No active sprint right now.", "yellow"))
 
-    tasks = [t for t in data.get("tasks", [])
-             if t.get("status") != "done" and not t.get("cross_sprint_parent")]
+    tasks = [t for t in data.get("tasks", []) if t.get("status") != "done"]
     if not tasks:
         print(c("  No active tasks.", "dim"))
         print()
         return
 
     at = data.get("active_timer")
-    by_sprint = {}
+    groups: dict[str | None, list] = {}
     for t in tasks:
-        by_sprint.setdefault(t.get("sprint", "Unassigned"), []).append(t)
+        group = _task_group_sprint(t, all_sprints, current)
+        groups.setdefault(group["id"] if group else None, []).append(t)
 
-    for sprint_name in sorted(by_sprint.keys()):
-        sprint_tasks = by_sprint[sprint_name]
-        print(c(f"\n  {sprint_name}", "bold"))
-        for t in sprint_tasks:
-            logged = task_logged_mins(t) + task_live_mins(t, at)
+    by_id = {s["id"]: s for s in all_sprints if s.get("id")}
+
+    def group_key(sid):
+        # Newest sprint first; "Unassigned" always last.
+        s = by_id.get(sid)
+        return (1, None) if s is None else (0, -s["start_date"].toordinal())
+
+    for sid in sorted(groups, key=group_key):
+        sprint = by_id.get(sid)
+        label = sprint["title"] if sprint else "Unassigned"
+        if sprint:
+            label += f"  ({sprint['start_date']} → {sprint['end_date'] - timedelta(days=1)})"
+        print(c(f"\n  {label}", "bold"))
+        for t in groups[sid]:
+            total = task_logged_mins(t) + task_live_mins(t, at)
+            in_sprint = (task_mins_for_sprint(t, sid, all_sprints) if sid else 0.0)
+            in_sprint += task_live_mins(t, at) if sid and sid == (current or {}).get("id") else 0
             running = at and at.get("task_id") == t["id"]
             dot = c("▶ ", "green") if running else "  "
-            print(f"    {dot}{t['title'][:50]:<52} {fmt_mins(logged)}")
+            notes = []
+            if sid and abs(in_sprint - total) > 1e-9:
+                notes.append(f"total {fmt_mins(total)}")
+            start = task_start_sprint(t, all_sprints)
+            group = by_id.get(sid)
+            if (start and group and start["id"] != sid
+                    and start["start_date"] < group["start_date"]):
+                # Carry-over: the work began in a *strictly earlier* sprint
+                # (plan §3). A start sprint that is later than the group sprint
+                # means the task's binding is behind its logs — that shows up as
+                # the "total" note instead, and `wt sync-sprints` fixes it.
+                notes.append(f"started {start['title']}")
+            suffix = c("  (" + ", ".join(notes) + ")", "dim") if notes else ""
+            shown = fmt_mins(in_sprint) if sid else fmt_mins(total)
+            print(f"    {dot}{t['title'][:50]:<52} {shown}{suffix}")
     print()
 
 
 def cmd_set_sprint(args):
-    """Set or change the sprint for a task."""
+    """Correct the sprint a task *started* in (plan §2.1/§3).
+
+    Since Phase 3, which sprint a task's hours are billed to is derived from its
+    log timestamps and materialised as ``sprint_issues`` bindings by
+    ``wt sync-sprints`` — it is not something you set by hand any more. The one
+    sprint field a human still owns is ``start_sprint``: "when did this work
+    begin", used for the "started Sprint N" carry-over marker in ``wt sprint``.
+    It is derived from the earliest log on first migration and then frozen, so a
+    later log edit can't silently rewrite history; this command is the override.
+    """
     if len(args) < 2:
-        print("Usage: wt set-sprint <task> <sprint-title>")
+        print("Usage: wt set-sprint <task> <sprint-title|none>")
+        print("  Corrects the sprint the task STARTED in (start_sprint).")
+        print("  Hours are attributed from log timestamps — run 'wt sync-sprints <task>'.")
         sys.exit(1)
 
     data = load()
-    all_sprints = get_all_sprints(data)
+    all_sprints, _ = _sprints_for_cli(data)
     if not all_sprints:
         print(c("No sprints found.", "red")); sys.exit(1)
 
@@ -5923,10 +6214,14 @@ def cmd_set_sprint(args):
     sprint_query = " ".join(args[1:])
 
     if sprint_query.lower() == "none":
-        task.pop("sprint", None)
-        task.pop("sprint_id", None)
+        had = task.pop("start_sprint_id", None) is not None
+        had = (task.pop("start_sprint", None) is not None) or had
         save(data)
-        print(c(f"✓ Cleared sprint for '{task['title']}'", "green"))
+        if had:
+            print(c(f"✓ Cleared start sprint for '{task['title']}'", "green"))
+            print(c("  It will be re-derived from the task's earliest log.", "dim"))
+        else:
+            print(c(f"'{task['title']}' had no start sprint set.", "dim"))
         return
 
     match = _match_sprint(all_sprints, sprint_query)
@@ -5938,14 +6233,16 @@ def cmd_set_sprint(args):
             print(c(f"    {s['title']}", "dim"))
         sys.exit(1)
 
-    task["sprint"] = match["title"]
-    task["sprint_id"] = match["id"]
+    task["start_sprint"] = match["title"]
+    task["start_sprint_id"] = match["id"]
     save(data)
-    print(c(f"✓ Set sprint for '{task['title']}' to {match['title']}", "green"))
+    print(c(f"✓ '{task['title']}' now starts in {match['title']}", "green"))
+    print(c("  (start sprint only — hours follow the logs; "
+            "run 'wt sync-sprints' to re-derive bindings)", "dim"))
 
 
 def _print_push_hint(task):
-    if task.get("github_issue"):
+    if task_current_issue(task):
         print(c(f"  Run: wt push {task['id']} to sync project fields", "dim"))
 
 
@@ -6023,69 +6320,254 @@ def cmd_set_type(args):
     _cmd_set_project_option(args, "type", "Type")
 
 
-def cmd_split_sprint(args):
-    """Split cross-sprint task: create shadow tasks for previous sprints."""
-    if not args:
-        print("Usage: wt split-sprint <task>"); sys.exit(1)
+# ── Sprint reconcile (`wt sync-sprints`, formerly `wt split-sprint`) ──────────
+
+def _reconcile_plan_lines(res: dict) -> list[str]:
+    """Human-readable, itemised description of what a reconcile *would* do.
+
+    Reads only the plan (``res["planned"]``) plus the read-only ``skipped``
+    entries, so it is safe to render from a ``dry_run=True`` result.
+    """
+    lines: list[str] = []
+    # Sprints getting a brand-new issue in this same plan: their close op has no
+    # issue ref yet, so name it "the new issue" rather than "(no issue)".
+    to_create = {op["sprint_id"] for op in res.get("planned", [])
+                 if op["op"] == "create" and op.get("create_issue")}
+    for op in res.get("planned", []):
+        sprint = op.get("sprint") or op.get("sprint_id") or "?"
+        kind = op["op"]
+        if kind == "create":
+            if op.get("create_issue"):
+                lines.append(f"create  {sprint:<12} new issue \"{op['issue_title']}\" "
+                             f"in {op['repo']} — {fmt_mins(op['minutes'])} → {op['hours']}h"
+                             + ("  (then close)" if op.get("will_close") else ""))
+            else:
+                why = op.get("skipped_github") or "no repo"
+                lines.append(f"create  {sprint:<12} local binding only ({why}) — "
+                             f"{fmt_mins(op['minutes'])}")
+        elif kind == "repoint":
+            lines.append(f"repoint {sprint:<12} carry {op['issue']} forward from "
+                         f"{op.get('from_sprint') or 'no sprint'} — "
+                         f"{fmt_mins(op['minutes'])} → {op['hours']}h")
+        elif kind == "hours":
+            was = op.get("from_hours")
+            was_s = "unknown" if was is None else f"{was}h"
+            lines.append(f"hours   {sprint:<12} {op['issue']}: {was_s} → {op['hours']}h "
+                         f"({fmt_mins(op['minutes'])})")
+        elif kind == "close":
+            if op.get("issue"):
+                what = op["issue"]
+            elif op["sprint_id"] in to_create:
+                what = "the issue created above"
+            else:
+                what = "(binding has no issue — nothing to close on GitHub)"
+            lines.append(f"close   {sprint:<12} {what} — sprint has ended")
+        elif kind == "relabel":
+            lines.append(f"relabel {sprint:<12} task sprint pointer moves from "
+                         f"{op.get('from_sprint') or 'none'}")
+    for sk in res.get("skipped", []):
+        if sk.get("needs_issue"):
+            lines.append(f"SKIP    {sk.get('sprint'):<12} {fmt_mins(sk.get('minutes') or 0)} "
+                         f"has no issue — re-run with --create-issues to mint one")
+        elif sk.get("reason") == "binding has no issue" and (sk.get("minutes") or 0) > 0:
+            # A binding that exists but was never linked: the task has never had a
+            # GitHub issue for that sprint. `wt done` creates the first one;
+            # reconcile only mints issues for *unbound* sprints.
+            lines.append(f"note    {sk.get('sprint'):<12} {fmt_mins(sk['minutes'])} bound but "
+                         f"never linked to an issue — use 'wt link' or 'wt done'")
+    if res.get("unassigned_minutes"):
+        lines.append(f"note    {'':<12} {fmt_mins(res['unassigned_minutes'])} of logs fall "
+                     f"outside every sprint (not reported to GitHub)")
+    return lines
+
+
+def _reconcile_outcome_lines(res: dict) -> list[str]:
+    """Human-readable description of what a reconcile actually did."""
+    lines: list[str] = []
+    for e in res.get("created", []):
+        issue = e.get("issue") or f"local binding only ({e.get('skipped_github') or 'no repo'})"
+        lines.append(f"+ {e['sprint']}: {fmt_mins(e['minutes'])} → {issue}")
+    for e in res.get("repointed", []):
+        lines.append(f"→ {e['sprint']}: carried {e['issue']} forward from "
+                     f"{e.get('from_sprint') or 'no sprint'}")
+    for e in res.get("hours_updated", []):
+        was = e.get("from_hours")
+        was_s = "unknown" if was is None else f"{was}h"
+        lines.append(f"= {e['sprint']}: {e['issue']} hours {was_s} → {e['hours']}h")
+    for e in res.get("closed", []):
+        lines.append(f"x {e['sprint']}: closed {e.get('issue') or '(no issue)'}")
+    if res.get("relabeled"):
+        r = res["relabeled"]
+        lines.append(f". sprint pointer now {r['sprint']} (was {r.get('from_sprint') or 'none'})")
+    for sk in res.get("skipped", []):
+        if sk.get("needs_issue"):
+            lines.append(f"! {sk.get('sprint')}: {fmt_mins(sk.get('minutes') or 0)} unbilled — "
+                         f"re-run with --create-issues")
+    for e in res.get("errors", []):
+        lines.append(f"✗ {e.get('sprint')}: {e['error']}")
+    return lines
+
+
+def cmd_sync_sprints(args):
+    """Reconcile a task's per-sprint issue bindings with its logs (plan §2.3).
+
+    Replaces ``wt split-sprint``. Idempotent: a second run finds nothing to do.
+    """
+    dry_run = all_tasks = create_issues_flag = assume_yes = False
+    query_parts: list[str] = []
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a in ("--dry-run", "-n"):
+            dry_run = True; i += 1
+        elif a == "--all":
+            all_tasks = True; i += 1
+        elif a == "--create-issues":
+            create_issues_flag = True; i += 1
+        elif a in ("--yes", "-y"):
+            assume_yes = True; i += 1
+        elif a in ("-h", "--help"):
+            print("Usage: wt sync-sprints [<task>] [--all] [--create-issues] [--dry-run] [--yes]")
+            print("  <task>           reconcile one task (mints past-sprint issues as needed)")
+            print("  --all            reconcile every non-recurrent task; does NOT create")
+            print("                   issues unless --create-issues is also given")
+            print("  --create-issues  allow minting new past-sprint GitHub issues")
+            print("  --dry-run / -n   print the plan and exit, changing nothing")
+            print("  --yes / -y       skip the confirmation prompt")
+            return
+        elif a.startswith("-"):
+            print(c(f"Unknown flag: {a}", "red")); sys.exit(1)
+        else:
+            query_parts.append(a); i += 1
+
+    if all_tasks and query_parts:
+        print(c("Give either a task or --all, not both.", "red")); sys.exit(1)
+    if not all_tasks and not query_parts:
+        print("Usage: wt sync-sprints [<task>] [--all] [--create-issues] [--dry-run]")
+        sys.exit(1)
 
     data = load()
-    task = resolve_task(data, " ".join(args))
-    all_sprints = get_all_sprints(data)
-
+    all_sprints, from_cache = _sprints_for_cli(data)
     if not all_sprints:
-        print(c("No sprints found.", "red")); sys.exit(1)
+        print(c("No sprints found (project not configured or query failed).", "red"))
+        sys.exit(1)
+    if from_cache:
+        print(c("(offline — using the persisted sprints cache)", "dim"))
 
-    summary = sprint_summary_for_task(task, all_sprints)
-    if len(summary) <= 1:
-        sprint_name = summary[0]["sprint_title"] if summary else task.get("sprint", "unknown")
-        print(c(f"Task '{task['title']}' only has time in {sprint_name}. No split needed.", "dim"))
+    # Requirement (a): a blanket run must not mint issues by default. On the real
+    # data an unrestricted --all would create 25 GitHub issues and close 25, so
+    # --all is hours-and-closes only until --create-issues is passed explicitly.
+    create_issues = create_issues_flag or not all_tasks
+
+    if all_tasks:
+        candidates = list(data.get("tasks", []))
+    else:
+        candidates = [resolve_task(data, " ".join(query_parts))]
+
+    # Requirement (b): recurrent tasks intentionally span sprints and are handled
+    # by wt close-recurrent / wt new-recurrent, which is also why close_task()
+    # excludes them. Reconciling them would mint past-sprint issues for every
+    # "… - Sprint N" copy, which is not today's behaviour.
+    targets, skipped_tasks = [], []
+    for t in candidates:
+        if t.get("status") == "recurrent":
+            skipped_tasks.append((t, "recurrent — use wt close-recurrent / wt new-recurrent"))
+            continue
+        targets.append(t)
+
+    # Plan pass: dry_run=True is structurally read-only (see reconcile_task_sprints).
+    plans = []
+    for t in targets:
+        res = reconcile_task_sprints(t, data, all_sprints, create_issues=create_issues,
+                                     dry_run=True)
+        if res.get("error") or res.get("planned") or any(
+            sk.get("needs_issue") for sk in res.get("skipped", [])
+        ):
+            plans.append((t, res))
+
+    if skipped_tasks:
+        print(c(f"\n  Skipped {len(skipped_tasks)} task(s):", "yellow"))
+        for t, why in skipped_tasks:
+            print(c(f"    • {t['title']}  [{t.get('sprint', '?')}]  — {why}", "dim"))
+
+    if not plans:
+        print(c(f"\n  Nothing to do ({len(targets)} task(s) already in sync).", "dim"))
         return
 
-    # Sprints already billed to their own issue (shadow task or binding) won't
-    # be recreated — same set the split itself uses.
-    existing_shadow_sprint_ids = existing_split_sprint_ids(task, data)
+    n_create = n_repoint = n_hours = n_close = n_needs_issue = 0
+    print(c(f"\n  Plan for {len(plans)} task(s):", "bold"))
+    for t, res in plans:
+        print(c(f"\n    {t['title']}", "cyan"))
+        if res.get("error"):
+            print(c(f"      ! {res['error']}", "red"))
+            continue
+        breakdown = ", ".join(
+            f"{e['sprint']}={fmt_mins(e['minutes'])}" for e in res.get("target", [])
+        )
+        if breakdown:
+            print(c(f"      logs by sprint: {breakdown}", "dim"))
+        for line in _reconcile_plan_lines(res):
+            print(f"      {line}")
+        for op in res.get("planned", []):
+            if op["op"] == "create":
+                n_create += 1 if op.get("create_issue") else 0
+            elif op["op"] == "repoint":
+                n_repoint += 1
+            elif op["op"] == "hours":
+                n_hours += 1
+            elif op["op"] == "close":
+                n_close += 1
+        n_needs_issue += sum(1 for sk in res.get("skipped", []) if sk.get("needs_issue"))
 
-    # Show breakdown
-    print(c(f"\n  Sprint breakdown for: {task['title']}\n", "bold"))
-    for s in summary:
-        if s == summary[-1]:
-            marker = " ← current"
-        elif s["sprint_id"] in existing_shadow_sprint_ids:
-            marker = " (already split)"
-        else:
-            marker = ""
-        print(f"    {s['sprint_title']:<20} {fmt_mins(s['total_mins']):<10} ({len(s['logs'])} logs){marker}")
+    print(c(f"\n  Totals: {n_create} issue(s) to create, {n_repoint} to re-point, "
+            f"{n_hours} hours update(s), {n_close} issue(s) to close.", "bold"))
+    if n_needs_issue:
+        print(c(f"  {n_needs_issue} past sprint(s) with unbilled time were NOT bound "
+                f"(no --create-issues).", "yellow"))
+    if all_tasks and not create_issues_flag:
+        print(c("  --all does not create GitHub issues; add --create-issues to allow it.",
+                "dim"))
 
-    to_create = sum(
-        1 for s in summary[:-1]
-        if s["sprint_id"] not in existing_shadow_sprint_ids
-    )
-    if to_create == 0:
-        print(c("\n  All previous sprints are already split. Nothing to do.", "dim"))
+    if dry_run:
+        print(c("\n  Dry run — nothing was changed.", "yellow"))
         return
-    print(f"\n  This will create {to_create} shadow task(s) for previous sprints.")
-    try:
-        response = input("  Proceed? [Y/n]: ").strip().lower()
-    except (EOFError, KeyboardInterrupt):
-        print(); return
 
-    if response in ("n", "no"):
-        return
+    if not assume_yes:
+        try:
+            response = input("\n  Proceed? [Y/n]: ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print(); return
+        if response in ("n", "no"):
+            print(c("  Aborted.", "yellow"))
+            return
 
     def on_progress(msg):
-        print(c(f"  {msg}", "dim"), flush=True)
+        print(c(f"    {msg}", "dim"), flush=True)
 
-    result = split_cross_sprint_task(task, data, save, all_sprints, progress_callback=on_progress)
-    if result.get("success"):
-        for st in result.get("sprint_tasks_created", []):
-            if st.get("skipped"):
-                print(c(f"  • {st['sprint']}: skipped ({st['skipped']})", "dim"))
-                continue
-            issue = st.get("issue_ref", "no issue")
-            print(c(f"  ✓ {st['sprint']}: {fmt_mins(st['total_mins'])} → {issue}", "green"))
-        print(c(f"  ✓ Main task updated to {result.get('main_sprint', '?')}", "green"))
-    else:
-        print(c(f"  ✗ Split failed: {result.get('error', 'unknown')}", "red"))
+    failures = 0
+    for t, _plan in plans:
+        print(c(f"\n  {t['title']}", "cyan"))
+        res = reconcile_task_sprints(t, data, all_sprints, create_issues=create_issues,
+                                     save_callback=save, progress_callback=on_progress)
+        lines = _reconcile_outcome_lines(res)
+        for line in lines:
+            print(c(f"    {line}", "green" if not line.startswith(("✗", "!")) else "yellow"))
+        if not lines:
+            print(c("    (nothing to do)", "dim"))
+        if not res.get("success"):
+            failures += 1
+    save(data)
+    if failures:
+        print(c(f"\n  {failures} task(s) had errors.", "red"))
+        sys.exit(1)
+    print(c("\n  Done.", "green"))
+
+
+def cmd_split_sprint(args):
+    """**Deprecated** alias for ``wt sync-sprints``."""
+    print(c("Note: 'wt split-sprint' is deprecated — use 'wt sync-sprints' "
+            "(same arguments, plus --all / --dry-run / --create-issues).", "yellow"))
+    cmd_sync_sprints(args)
 
 
 COMMANDS = {
@@ -6125,7 +6607,8 @@ COMMANDS = {
     "report": cmd_report,
     "sprint": cmd_sprint,
     "set-sprint": cmd_set_sprint,
-    "split-sprint": cmd_split_sprint,
+    "sync-sprints": cmd_sync_sprints,
+    "split-sprint": cmd_split_sprint,  # deprecated alias for sync-sprints
     "set-repo": cmd_set_repo,
     "set-activity": cmd_set_activity,
     "set-type": cmd_set_type,

--- a/wt.py
+++ b/wt.py
@@ -96,7 +96,20 @@ import time
 from pathlib import Path
 from datetime import datetime, timedelta
 
-DATA_FILE = Path.home() / ".workload_tracker.json"
+def _resolve_data_file() -> Path:
+    """Where the tracker's JSON lives.
+
+    Defaults to ``~/.workload_tracker.json``. ``WT_DATA_FILE`` overrides it so
+    migrations and refactors can be exercised against a throwaway copy instead
+    of the live, iCloud-synced source of truth. Production runs never set it.
+    """
+    override = os.environ.get("WT_DATA_FILE", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".workload_tracker.json"
+
+
+DATA_FILE = _resolve_data_file()
 NOTES_DIR = Path.home() / ".workload_tracker_notes"
 
 DEFAULT_ROLES = [

--- a/wt.py
+++ b/wt.py
@@ -155,6 +155,9 @@ def load() -> dict:
     # Move github_repo/activity/type from roles onto tasks (one-time copy,
     # roles stripped on every load). Idempotent on subsequent runs.
     mutated = _migrate_role_github_fields(data) or mutated
+    # Convert cross-sprint shadow tasks into per-sprint issue bindings (one-time),
+    # and strip re-introduced shadows on every load. Idempotent.
+    mutated = _migrate_shadows_to_bindings(data) or mutated
     if mutated:
         save(data)
     return data
@@ -354,6 +357,192 @@ def _migrate_role_github_fields(data: dict) -> bool:
     return mutated
 
 
+def _merge_binding(bindings: list[dict], new: dict) -> bool:
+    """Append *new* to *bindings* unless its sprint_id is already bound.
+
+    One binding per sprint (plan §6 invariant 4). On collision the entry that
+    carries an ``issue`` wins; otherwise the incumbent is kept. Returns True if
+    *bindings* was modified.
+    """
+    sprint_id = new.get("sprint_id")
+    existing = None
+    if sprint_id:
+        existing = next((b for b in bindings if b.get("sprint_id") == sprint_id), None)
+    if existing is None:
+        bindings.append(new)
+        return True
+    if new.get("issue") and not existing.get("issue"):
+        bindings[bindings.index(existing)] = new
+        return True
+    return False
+
+
+def _dedupe_bindings(task: dict) -> bool:
+    """Collapse duplicate sprint_ids in a task's bindings. True if changed."""
+    bindings = task.get("sprint_issues")
+    if not isinstance(bindings, list) or len(bindings) < 2:
+        return False
+    kept: list[dict] = []
+    for b in bindings:
+        _merge_binding(kept, b)
+    if len(kept) == len(bindings):
+        return False
+    task["sprint_issues"] = kept
+    return True
+
+
+def _sort_task_bindings(task: dict, sprints: list[dict]) -> bool:
+    """Store a task's bindings in chronological (sprint start_date) order.
+
+    Keeping the persisted list sorted means "the last binding" is always the
+    most recent sprint, so ``task_current_issue(task)`` picks the right issue
+    even when it is called without *data* (no sprint cache to sort by). Bindings
+    whose sprint can't be resolved keep sorting first, so they never become the
+    accidental "current" one. Returns True if the order changed.
+    """
+    bindings = task.get("sprint_issues")
+    if not isinstance(bindings, list) or len(bindings) < 2:
+        return False
+    start_by_id = {s["id"]: s.get("start_date") for s in (sprints or [])}
+    ordered = sorted(
+        bindings,
+        key=lambda b: _sprint_start_sort_key(start_by_id.get(b.get("sprint_id"))),
+    )
+    if ordered == bindings:
+        return False
+    task["sprint_issues"] = ordered
+    return True
+
+
+def _ensure_bindings(task: dict) -> list[dict]:
+    """Return the task's ``sprint_issues`` list, seeding it from legacy fields."""
+    bindings = task.get("sprint_issues")
+    if not isinstance(bindings, list):
+        legacy = _legacy_binding_for_task(task)
+        bindings = [legacy] if legacy else []
+        task["sprint_issues"] = bindings
+    return bindings
+
+
+def _shadow_binding(shadow: dict) -> dict:
+    """Build the parent binding that replaces a shadow task object.
+
+    The shadow's hours are preserved as ``hours_synced`` (what GitHub was told)
+    and its newest log timestamp as ``synced_at``. Its synthetic "Sprint split"
+    marker log is deliberately dropped: the parent already holds the real logs,
+    so merging would double-count (plan §4 Phase 1, step 4).
+    """
+    logs = shadow.get("logs", []) or []
+    marker_mins = sum(l.get("minutes", 0) for l in logs)
+    stamps = [l.get("at") for l in logs if l.get("at")]
+    return {
+        "sprint_id": shadow.get("sprint_id"),
+        "sprint": shadow.get("sprint"),
+        "issue": shadow.get("github_issue"),
+        "state": "closed",
+        "hours_synced": mins_to_quarter_hours(marker_mins) if marker_mins else None,
+        "synced_at": max(stamps) if stamps else None,
+        "created_at": shadow.get("created_at"),
+    }
+
+
+def _migrate_shadows_to_bindings(data: dict) -> bool:
+    """Replace cross-sprint shadow tasks with per-sprint issue bindings.
+
+    See docs/plan-sprint-bindings.md §2.1/§4. Two parts:
+
+      * One-time conversion (guarded by ``config["sprint_bindings_migrated"]``):
+        give every task a ``sprint_issues`` list seeded from its legacy
+        ``sprint_id``/``github_issue``, and freeze ``start_sprint_id`` /
+        ``start_sprint`` from its earliest log (offline, via the sprints cache;
+        left unset when the sprint can't be resolved).
+      * Shadow sweep (**every load**): any task carrying ``cross_sprint_parent``
+        is converted into a binding on its parent and deleted, mirroring how
+        ``_migrate_role_github_fields`` keeps stripping legacy role keys — an
+        older wt.py on another Mac can re-introduce shadows via iCloud.
+
+    Legacy ``sprint``/``sprint_id``/``github_issue`` keys are kept (Phase 1 is
+    additive plus shadow removal; Phase 3 stops reading them). ``logs`` and the
+    per-task ``github_repo``/``activity``/``type`` are never touched.
+
+    Orphan shadows (parent id not in the data) are left alone and reported via
+    ``logging.warning`` rather than silently deleted.
+
+    Returns True if any mutation occurred. Idempotent on repeat runs.
+    """
+    mutated = False
+    config = data.setdefault("config", {})
+    tasks = data.get("tasks", [])
+    first_run = not config.get("sprint_bindings_migrated")
+
+    # 1. Seed each real task's bindings from its legacy fields (one-time).
+    if first_run:
+        for task in tasks:
+            if task.get("cross_sprint_parent"):
+                continue  # shadows are removed below, not migrated
+            if task.get("sprint_issues") is None:
+                _ensure_bindings(task)
+                mutated = True
+
+    # 2/4. Convert shadows into parent bindings and drop the shadow objects.
+    by_id = {t["id"]: t for t in tasks if t.get("id")}
+    survivors = []
+    orphans = []
+    for task in tasks:
+        parent_id = task.get("cross_sprint_parent")
+        if not parent_id:
+            survivors.append(task)
+            continue
+        parent = by_id.get(parent_id)
+        if parent is None:
+            # 5. Orphan: keep it, report it. Never destroy data we can't re-home.
+            orphans.append(task)
+            survivors.append(task)
+            continue
+        if _merge_binding(_ensure_bindings(parent), _shadow_binding(task)):
+            mutated = True
+        mutated = True  # the shadow object itself goes away
+    if len(survivors) != len(tasks):
+        data["tasks"] = survivors
+        tasks = survivors
+
+    if orphans:
+        logging.warning(
+            "sprint bindings migration: %d shadow task(s) kept — parent missing: %s",
+            len(orphans),
+            ", ".join(f"{t.get('title', '?')} (parent {t.get('cross_sprint_parent')})"
+                      for t in orphans),
+        )
+
+    # Sprint dates come from the persisted cache — this migration never touches
+    # the network (load() must stay offline).
+    sprints = get_cached_sprints(data)
+
+    # 3. Freeze the start sprint from the earliest log (one-time, offline).
+    if first_run:
+        if sprints:
+            for task in tasks:
+                if task.get("cross_sprint_parent") or task.get("start_sprint_id"):
+                    continue
+                start = task_start_sprint(task, sprints)
+                if start:
+                    task["start_sprint_id"] = start["id"]
+                    task["start_sprint"] = start["title"]
+                    mutated = True
+        config["sprint_bindings_migrated"] = True
+        mutated = True
+
+    # 9. One binding per sprint, always — and keep the list chronological so
+    #    bindings[-1] is the most recent sprint.
+    for task in tasks:
+        if _dedupe_bindings(task):
+            mutated = True
+        if _sort_task_bindings(task, sprints):
+            mutated = True
+
+    return mutated
+
+
 def resolve_task_by_id(data: dict, task_id: str) -> dict | None:
     """Find a task by its exact ID."""
     return next((t for t in data.get("tasks", []) if t["id"] == task_id), None)
@@ -479,6 +668,30 @@ def task_logged_mins_for_sprint(task: dict, sprints: list) -> float:
         if sprint["start_date"] <= log_date < sprint["end_date"]:
             total += log.get("minutes", 0)
     return total
+
+
+def existing_split_sprint_ids(task: dict, data: dict) -> set:
+    """Sprints of *task* that a previous split already billed to their own issue.
+
+    Union of two representations of the same fact, so the split stays idempotent
+    across the Phase-1 migration:
+      * legacy shadow task objects (``cross_sprint_parent == task["id"]``), and
+      * the task's own ``sprint_issues`` bindings other than the one for its
+        current ``sprint_id`` (which is the main issue, not a split-off one).
+
+    Before migration this returns exactly the old shadow-id set.
+    """
+    ids = {
+        t.get("sprint_id")
+        for t in data.get("tasks", [])
+        if t.get("cross_sprint_parent") == task.get("id")
+    }
+    own = task.get("sprint_id")
+    for binding in task_sprint_bindings(task):
+        sprint_id = binding.get("sprint_id")
+        if sprint_id and sprint_id != own:
+            ids.add(sprint_id)
+    return ids
 
 
 def task_uploaded_mins(task: dict) -> float:
@@ -1024,13 +1237,27 @@ def bucket_logs_by_sprint(task: dict, sprints: list[dict]) -> dict:
     return buckets
 
 
-def sprint_summary_for_task(task: dict, sprints: list[dict]) -> list[dict]:
-    """Get per-sprint breakdown of logged time for a task.
+def _sprint_start_sort_key(start_date):
+    """Sort key for a sprint's start_date that tolerates None/unknown sprints.
 
-    Returns list of dicts sorted by sprint start date:
-        [{sprint_id, sprint_title, field_id, start_date, logs, total_mins}, ...]
-    Only includes sprints that have logged time (excludes None bucket).
+    Unresolvable sprints sort first (they can never be "the most recent").
     """
+    from datetime import date
+    return start_date if start_date is not None else date.min
+
+
+def _sprint_time_entries(task: dict, sprints: list[dict], include_zero: bool = False) -> list[dict]:
+    """Per-sprint breakdown of a task's logged time, sorted by sprint start date.
+
+    Shared implementation behind ``sprint_summary_for_task`` (legacy, keeps
+    zero-minute sprints) and ``task_sprints_with_time`` (drops them).
+
+    ``start_date`` in each entry is the sprint's ``start_date`` **date object**,
+    which both ``get_all_sprints()`` and ``get_cached_sprints()`` provide — the
+    old code read the camelCase ``startDate`` that only the former produces, so
+    passing cached sprints sorted every entry by ``""`` (see plan §1.7).
+    """
+    sprints = sprints or []
     buckets = bucket_logs_by_sprint(task, sprints)
     sprint_map = {s["id"]: s for s in sprints}
     result = []
@@ -1038,16 +1265,180 @@ def sprint_summary_for_task(task: dict, sprints: list[dict]) -> list[dict]:
         if sprint_id is None:
             continue
         s = sprint_map.get(sprint_id, {})
+        total_mins = sum(l.get("minutes", 0) for l in logs)
+        if not include_zero and total_mins <= 0:
+            continue
         result.append({
             "sprint_id": sprint_id,
             "sprint_title": s.get("title", "Unknown"),
             "field_id": s.get("field_id"),
-            "start_date": s.get("startDate", ""),
+            "start_date": s.get("start_date"),
             "logs": logs,
-            "total_mins": sum(l.get("minutes", 0) for l in logs),
+            "total_mins": total_mins,
         })
-    result.sort(key=lambda x: x["start_date"])
+    result.sort(key=lambda x: _sprint_start_sort_key(x["start_date"]))
     return result
+
+
+def sprint_summary_for_task(task: dict, sprints: list[dict]) -> list[dict]:
+    """Get per-sprint breakdown of logged time for a task.
+
+    Returns list of dicts sorted by sprint start date:
+        [{sprint_id, sprint_title, field_id, start_date, logs, total_mins}, ...]
+    Only includes sprints that have logged time (excludes None bucket).
+
+    Legacy shim: delegates to ``_sprint_time_entries`` with ``include_zero=True``
+    so its current callers (the split machinery, which relies on zero-minute
+    "sprint rollover marker" logs creating a bucket) keep their behaviour while
+    picking up the start_date sort fix. New code should use
+    ``task_sprints_with_time``.
+    """
+    return _sprint_time_entries(task, sprints, include_zero=True)
+
+
+def task_sprints_with_time(task: dict, sprints: list[dict]) -> list[dict]:
+    """Sprints in which this task has logged time, oldest first.
+
+    Replacement for ``sprint_summary_for_task``: same entry shape
+    ``{sprint_id, sprint_title, field_id, start_date, logs, total_mins}`` but
+    sorted by the real ``start_date`` date object and excluding sprints whose
+    total is zero (e.g. the marker-log hack of plan §1.3).
+    """
+    return _sprint_time_entries(task, sprints, include_zero=False)
+
+
+# --- Per-sprint issue bindings (plan §2.1/§2.2) --------------------------------
+#
+# A task carries ``sprint_issues``: one binding per sprint the work was billed
+# to, replacing the "shadow task" duplicates. Every accessor below falls back to
+# the legacy ``sprint``/``sprint_id``/``github_issue`` fields, so they are safe
+# to call on un-migrated data.
+
+
+def _legacy_binding_for_task(task: dict) -> dict | None:
+    """Synthesize a binding from a task's legacy sprint/issue fields.
+
+    Returns None when the task has neither a ``sprint_id`` nor a
+    ``github_issue`` (nothing to bind).
+    """
+    sprint_id = task.get("sprint_id")
+    issue = task.get("github_issue")
+    if not sprint_id and not issue:
+        return None
+    return {
+        "sprint_id": sprint_id,
+        "sprint": task.get("sprint"),
+        "issue": issue,
+        "state": "closed" if task.get("status") == "done" else "open",
+        "hours_synced": None,
+        "synced_at": None,
+        "created_at": task.get("created_at"),
+    }
+
+
+def task_sprint_bindings(task: dict, sprints: list[dict] = None) -> list[dict]:
+    """Return the task's per-sprint issue bindings. Never None.
+
+    Sorted by the binding's sprint ``start_date`` when *sprints* is supplied,
+    otherwise left in insertion order. When the task has no ``sprint_issues``
+    key at all (un-migrated data) a single binding is synthesized from the
+    legacy fields — synthesized, not persisted. An explicitly empty list is
+    respected as "this task has no bindings".
+    """
+    bindings = task.get("sprint_issues")
+    if bindings is None:
+        legacy = _legacy_binding_for_task(task)
+        bindings = [legacy] if legacy else []
+    elif not isinstance(bindings, list):
+        return []
+    if not sprints or not bindings:
+        return list(bindings)
+    start_by_id = {s["id"]: s.get("start_date") for s in sprints}
+    return sorted(
+        bindings,
+        key=lambda b: _sprint_start_sort_key(start_by_id.get(b.get("sprint_id"))),
+    )
+
+
+def task_binding_for_sprint(task: dict, sprint_id: str) -> dict | None:
+    """The task's binding for *sprint_id*, or None."""
+    if not sprint_id:
+        return None
+    for b in task_sprint_bindings(task):
+        if b.get("sprint_id") == sprint_id:
+            return b
+    return None
+
+
+def task_current_issue(task: dict, data: dict = None) -> str | None:
+    """The issue ref that "is" this task's current GitHub issue.
+
+    Resolution order:
+      1. The binding for the current sprint — resolved **offline** from
+         ``get_cached_sprints(data)`` + today's date when *data* is given.
+      2. The binding with the latest sprint ``start_date`` (needs the cache).
+      3. The last binding in insertion order.
+      4. The legacy ``task["github_issue"]``.
+
+    Never makes a network call, so it is safe on every hot path.
+    """
+    bindings = task_sprint_bindings(task)
+    candidates = []
+    if bindings:
+        sprints = get_cached_sprints(data) if data is not None else []
+        if sprints:
+            current = find_sprint_for_date(sprints, datetime.now().date())
+            if current:
+                b = next((x for x in bindings if x.get("sprint_id") == current["id"]), None)
+                if b is not None:
+                    candidates.append(b)
+            candidates.append(task_sprint_bindings(task, sprints)[-1])
+        candidates.append(bindings[-1])
+    for b in candidates:
+        if b.get("issue"):
+            return b["issue"]
+    return task.get("github_issue")
+
+
+def task_start_sprint(task: dict, sprints: list[dict]) -> dict | None:
+    """The sprint this task started in.
+
+    Uses the frozen ``start_sprint_id`` when set, otherwise derives it from the
+    task's earliest log (``log_effective_date``). Derive-only: this never writes
+    the field — freezing happens in ``_migrate_shadows_to_bindings``.
+    """
+    sprints = sprints or []
+    frozen = task.get("start_sprint_id")
+    if frozen:
+        return next((s for s in sprints if s["id"] == frozen), None)
+    stamps = [ts for ts in (log_effective_date(l) for l in task.get("logs", [])) if ts]
+    if not stamps:
+        return None
+    return find_sprint_for_date(sprints, datetime.fromtimestamp(min(stamps)).date())
+
+
+def task_mins_for_sprint(task: dict, sprint_id: str, sprints: list[dict]) -> float:
+    """Minutes logged by *task* inside *sprint_id*'s half-open date range.
+
+    Unlike the legacy ``task_logged_mins_for_sprint`` there is **no** "sprint
+    unknown → return the task total" fallback (which silently over-reports):
+    an unresolvable sprint, or a task whose logs carry no usable timestamp,
+    contributes 0.0 to that sprint.
+    """
+    if not sprint_id or not sprints:
+        return 0.0
+    sprint = next((s for s in sprints if s.get("id") == sprint_id), None)
+    if not sprint or not sprint.get("start_date") or not sprint.get("end_date"):
+        return 0.0
+    total = 0.0
+    for log in task.get("logs", []):
+        ts = log_effective_date(log)
+        if not ts:
+            continue
+        log_date = datetime.fromtimestamp(ts).date()
+        if sprint["start_date"] <= log_date < sprint["end_date"]:
+            total += log.get("minutes", 0)
+    return total
 
 
 def logs_in_date_range(
@@ -1310,13 +1701,10 @@ def split_cross_sprint_task(task: dict, data: dict, save_callback,
 
     # Idempotency: the main task keeps all its logs (source of truth), so a
     # re-split would otherwise re-detect the same previous sprints and create
-    # duplicate shadow tasks/issues. Skip any previous sprint that already has
-    # a shadow task for this parent.
-    existing_shadow_sprint_ids = {
-        t.get("sprint_id")
-        for t in data.get("tasks", [])
-        if t.get("cross_sprint_parent") == task["id"]
-    }
+    # duplicate shadow tasks/issues. Skip any previous sprint already billed to
+    # its own issue — as a shadow task, or as a per-sprint binding once the
+    # shadow-to-bindings migration has removed those shadow objects.
+    existing_shadow_sprint_ids = existing_split_sprint_ids(task, data)
 
     repo = get_task_repo(task)
     config = data.get("config", {})
@@ -5169,12 +5557,9 @@ def cmd_split_sprint(args):
         print(c(f"Task '{task['title']}' only has time in {sprint_name}. No split needed.", "dim"))
         return
 
-    # Sprints already split off into shadow tasks won't be recreated.
-    existing_shadow_sprint_ids = {
-        t.get("sprint_id")
-        for t in data.get("tasks", [])
-        if t.get("cross_sprint_parent") == task["id"]
-    }
+    # Sprints already billed to their own issue (shadow task or binding) won't
+    # be recreated — same set the split itself uses.
+    existing_shadow_sprint_ids = existing_split_sprint_ids(task, data)
 
     # Show breakdown
     print(c(f"\n  Sprint breakdown for: {task['title']}\n", "bold"))


### PR DESCRIPTION
Implements `docs/plan-sprint-bindings.md` phases 0-4 using **Option A**: the local representation changes, GitHub-side behaviour does not.

A task is no longer assigned to a sprint. It keeps one object forever with `sprint_issues[]` (one binding per sprint), `start_sprint*` frozen from its earliest log, and per-sprint hours derived from log timestamps. The 12 shadow tasks are migrated into bindings and deleted.

`split_cross_sprint_task` is replaced by `reconcile_task_sprints`, a pure diff between derived target state and existing bindings — so idempotency is structural and the 0-minute rollover marker-log ritual is gone.

## Three real bugs found and fixed on the way
- The split's idempotency guard scanned for shadow *tasks*, which the migration deletes, so the first post-migration `wt done` on a previously-split task would have **minted duplicate issues** for Sprints 98-101.
- MCP's `set_task_status(..., 'done')` was a hand-rolled reimplementation reporting `total_minutes / 60` — **the task's whole total**, double-counting cross-sprint work.
- `tracker.py`'s `_run_close_workflow` pushed the task total to the single linked issue. Both now delegate to `wt.close_task`.

Plus: `sprint_summary_for_task` sorted on the camelCase `startDate` key that only the live fetch emits, so cached sprints sorted by `""` and "most recent sprint" was arbitrary.

## Safety
`sync-sprints --all` does **not** create issues without `--create-issues` (a blanket run wants 25) and skips all 5 recurrent tasks. `dry_run` is write-free by construction.

Nothing ran against the live data file and no `gh` write was made: it is byte-identical to the pre-work backup at `~/workload_tracker.backup.2026-07-30.json`.

## Verified
4 stubbed harnesses under `tools/` (76 + 112 + 164 + 66 checks, the last via Textual's headless `run_test`). Migration is byte-identical across three loads; total minutes (26620.71) and log count (392) unchanged; `task_current_issue` equals the legacy field for all 80 tasks.

## Before merging
The migration runs on `load()`, so it fires on your **first `wt` command after merge**. The backup is in place. Section 6b lists 8 known follow-ups; section 7 Q4 (collapsing recurrent per-sprint copies) is deliberately unimplemented.

Not smoke-tested against real GitHub — the first live `S` and `D` in the TUI are worth watching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)