### PR TITLE
Close against the latest sprint with time, not an empty current sprint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -412,7 +412,9 @@ Linking an issue (`wt link`, MCP `link_github_issue`, `wt add-issue`, `create_ta
      reporting hours, so each prior sprint's hours land on that sprint's own
      issue and only the current sprint's hours go on the current binding (see
      "Reconcile workflow" below). It runs unconditionally — reconcile is
-     idempotent, so there's no "does this span sprints?" gate any more.
+     idempotent, so there's no "does this span sprints?" gate any more — and
+     with `closing=True`, so hours are reported against the latest sprint that
+     actually has time rather than an empty current sprint.
      `recurrent` tasks are skipped. A failed reconcile aborts the close (the task
      is **not** marked done) so hours can't be mis-reported.
    - Issue is added to the configured GitHub project (if configured)
@@ -636,6 +638,10 @@ a pure diff between derived target state and existing bindings —
 2. Target set = {sprints with time} ∪ {current sprint, if the task is open}.
    That second term is why the old **0-minute "rollover marker" log hack is
    unnecessary** — an open task always has a landing place for new work.
+   **`closing=True` drops it**: a task being closed has no future work, so
+   reserving an empty current-sprint binding would park its long-lived issue on
+   a sprint it was never worked in and report 0h there. `close_task()` always
+   passes it, which is why a close reports the **latest sprint with time**.
 3. Create a binding (and issue, if the task has a `github_repo`) for each
    missing target sprint. New issues are for *past* sprints and keep the
    ` (Sprint N)` title suffix.

--- a/docs/plan-sprint-bindings.md
+++ b/docs/plan-sprint-bindings.md
@@ -404,12 +404,24 @@ Deliberately left out of scope so the phases stayed reviewable. None affects the
 3. **`cmd_add` / `create_task_from_issue` set only `sprint`/`sprint_id`**, never
    `start_sprint*`, so `wt sprint`'s "started Sprint N" is blank for
    CLI-created tasks until their first reconcile. The TUI sets both.
-4. **Closing an open carry-over task can report 0h.** Reconcile targets the
-   current sprint for an open task, then `close_task` reports that binding — so
-   a task with no minutes yet in the current sprint closes its carried-forward
-   issue at 0.0h. This matches the old marker-log outcome, but reporting the
-   latest sprint *with time* may be the better rule. **Policy decision, not a
-   bug** — needs Carlos.
+4. ~~**Closing an open carry-over task can report 0h.**~~ **RESOLVED
+   2026-07-31 — now reports the latest sprint with time.** `close_task` passes
+   `closing=True` to the reconcile, which suppresses the "reserve the current
+   sprint for an open task" target. A task being closed has no future work to
+   land, so `latest` becomes the newest sprint that actually has minutes, and the
+   task's long-lived issue is carried there and reports *that* sprint's hours.
+   Open-task reconcile is unchanged — it still reserves the current sprint, which
+   is what makes the marker-log ritual unnecessary (§1.3).
+
+   **This is the first change that is not GitHub-neutral**, so Option A's "a
+   correct migration produces a zero GH diff" property (§2.4, §5) applies to
+   phases 0–4 only, not to this. Measured against the merged Phase 3 across the
+   12 previously-split tasks: 10 byte-identical, 2 differing, and in both the
+   only changes are (a) the Sprint field no longer parked on the current sprint,
+   (b) one fewer issue minted because the carried-forward issue absorbed the
+   newest sprint, and (c) `add_to_project_and_update` reporting 0.25h where it
+   used to report 0.0h. `tools/test_phase3.py` asserts exactly that allow-list,
+   so any *other* removed write fails the build.
 5. **A stray 8-second timer log mints a whole past-sprint issue** billed at
    0.25h, because `mins_to_quarter_hours` rounds up per sprint (preserved
    deliberately, §5). A minimum-minutes threshold in `_reconcile_plan` would

--- a/tools/test_mcp_phase3.py
+++ b/tools/test_mcp_phase3.py
@@ -535,8 +535,12 @@ def test_close_end_to_end(wt, mcp_server, migrated, scratch):
     print(f"       task={title[:52]!r} sprints={per_sprint} "
           f"bindings={len(bound_before)} unbound={[e['sprint_title'] for e in unbound]}")
 
+    # Plan with closing=True, which is what close_task passes: a task being
+    # closed gets no empty current-sprint binding, so its carried-forward issue
+    # lands on the newest sprint *with* time and one fewer issue is minted.
     with McpStubs(wt, mcp_server, mode="strict", sprints=sprints):
-        plan = wt.reconcile_task_sprints(task, data, sprints, dry_run=True)
+        plan = wt.reconcile_task_sprints(task, data, sprints, dry_run=True,
+                                         closing=True)
     want_mints = sum(1 for op in plan["planned"]
                      if op["op"] == "create" and op.get("create_issue"))
     want_closes = sum(1 for op in plan["planned"] if op["op"] == "close") + 1

--- a/tools/test_phase3.py
+++ b/tools/test_phase3.py
@@ -845,13 +845,56 @@ def test_close_task_github_diff(migrated, scratch):
     check(err == 0, "no task errored under either version", f"{err} error(s)")
     check(same >= 10, "at least 10 of 12 tasks have a byte-identical write sequence",
           f"same={same} diff={diff}")
-    # The two known diffs are extra writes of the *same* values — never a
-    # different value — plus one Sprint field that used to be left unset.
-    changed_values = [l for l in run.stdout.splitlines()
-                      if l.strip().startswith("-") and "---" not in l]
-    check(not changed_values,
-          "no GitHub write was REMOVED or had its value changed "
-          "(diffs are additions only)", "\n      ".join(changed_values))
+
+    # NOTE: this check used to assert "diffs are additions only", i.e. that the
+    # refactor never changed a GitHub-visible value (Option A's premise). The
+    # `closing=True` change to close_task deliberately breaks that, so the
+    # assertion is now narrower: the only writes a close may *remove* are
+    #   (a) Sprint-field writes pointing at the CURRENT sprint — the close no
+    #       longer parks a task's issue on a sprint it was never worked in, and
+    #   (b) the whole mint-a-past-sprint-issue block (NEW#n) for the newest
+    #       sprint with time, because the carried-forward issue now covers it.
+    # Anything else disappearing is a regression.
+    removed = [l.strip() for l in run.stdout.splitlines()
+               if l.strip().startswith("-") and "---" not in l]
+    import wt as _wt
+    current = _wt.find_sprint_for_date(
+        _wt.get_cached_sprints(json.loads(Path(migrated).read_text())),
+        __import__("datetime").date.today())
+    cur_id = (current or {}).get("id") or "\0"
+    def explained(line):
+        # (a) a Sprint field write parking an issue on the current sprint
+        if "update_project_sprint" in line and cur_id in line:
+            return True
+        # (b) any write against a newly-minted issue the new code doesn't need…
+        if "NEW#" in line:
+            return True
+        # …including the mint itself, whose line names the title, not NEW#n
+        if re.search(r"create_github_issue\('.*\(Sprint \d+\)'", line):
+            return True
+        # (c) the 0.0h report that this change exists to replace
+        if "add_to_project_and_update" in line and ", 0.0," in line:
+            return True
+        return False
+
+    unexplained = [l for l in removed if not explained(l)]
+    check(not unexplained,
+          "the only removed writes are current-sprint Sprint fields, absorbed "
+          "past-sprint issue mints, and the 0.0h report",
+          "\n      ".join(unexplained))
+    check(any("NEW#" in l for l in removed),
+          "at least one past-sprint issue is no longer minted "
+          "(absorbed by the carried-forward issue)", str(len(removed)))
+    # The point of the change: the main issue stops being told 0.0h.
+    zero_before = [l for l in run.stdout.splitlines()
+                   if l.strip().startswith("-")
+                   and "add_to_project_and_update" in l and ", 0.0," in l]
+    nonzero_after = [l for l in run.stdout.splitlines()
+                     if l.strip().startswith("+")
+                     and "add_to_project_and_update" in l and ", 0.0," not in l]
+    check(zero_before and nonzero_after,
+          "a close that used to report 0.0h now reports its real sprint hours",
+          f"before={len(zero_before)} after={len(nonzero_after)}")
 
 
 def test_reconcile_harness_still_passes(fixture, migrated, baseline, scratch):

--- a/tools/test_reconcile.py
+++ b/tools/test_reconcile.py
@@ -583,30 +583,39 @@ def test_close_task(wt, migrated, scratch):
           "no shadow task objects created")
     check(len(data["tasks"]) == 80, "no tasks added", str(len(data["tasks"])))
     bound = {b["sprint"]: b for b in task["sprint_issues"]}
-    check(set(bound) == {"Sprint 97", "Sprint 98", "Sprint 104", "Sprint 105"},
-          "a binding per sprint with time, plus the current sprint", str(sorted(bound)))
-    check(bound["Sprint 105"]["issue"] == issue,
-          "the original issue is the current-sprint one (Option A)",
-          str(bound["Sprint 105"]))
-    check(st.count("create_github_issue") == 2,
-          "two past-sprint issues minted (Sprint 98 and Sprint 104)",
+    # close_task passes closing=True, so no empty binding is reserved for the
+    # current sprint (Sprint 105 has no logs). The task's long-lived issue lands
+    # on the newest sprint that actually has time instead of reporting 0h against
+    # a sprint it was never worked in.
+    check(set(bound) == {"Sprint 97", "Sprint 98", "Sprint 104"},
+          "a binding per sprint with time, and no empty current-sprint binding",
+          str(sorted(bound)))
+    last = "Sprint 104"  # newest sprint with logged time
+    check(bound[last]["issue"] == issue,
+          "the original issue lands on the newest sprint with time (Option A)",
+          str(bound[last]))
+    check(st.count("create_github_issue") == 1,
+          "only Sprint 98 is minted (Sprint 104 took the carried-forward issue)",
           str(st.count("create_github_issue")))
-    check(all(b["state"] == "closed" for k, b in bound.items() if k != "Sprint 105"),
-          "past bindings closed", str(bound))
+    check(all(b["state"] == "closed" for b in bound.values()),
+          "every binding closed (all their sprints have ended)", str(bound))
     # Hours reported on the main issue must be the sprint-filtered value.
     hour_calls = [c for c in st.calls if c[0] == "update_project_hours"]
     print(f"    update_project_hours calls: "
           f"{[(c[1][0], c[1][1]) for c in hour_calls]}")
     main_hours = [c[1][1] for c in hour_calls if c[1][0] == issue]
     expected = wt.mins_to_quarter_hours(
-        wt.task_mins_for_sprint(task, bound["Sprint 105"]["sprint_id"], sprints))
+        wt.task_mins_for_sprint(task, bound[last]["sprint_id"], sprints))
     check(all(h == expected for h in main_hours),
-          f"main issue only ever told its current-sprint hours ({expected})",
+          f"main issue only ever told its own sprint's hours ({expected})",
           str(main_hours))
-    check(bound["Sprint 105"]["state"] == "closed"
-          and bound["Sprint 105"]["hours_synced"] == expected,
+    check(expected > 0,
+          "and that value is non-zero — the whole point of closing=True",
+          str(expected))
+    check(bound[last]["state"] == "closed"
+          and bound[last]["hours_synced"] == expected,
           "the current binding's cached state/hours match what close_task did",
-          str(bound["Sprint 105"]))
+          str(bound[last]))
     # A reconcile straight after must not try to re-close or re-push anything.
     with Stubs(wt, mode="strict", sprints=sprints) as st:
         after = wt.reconcile_task_sprints(task, data, sprints, save_callback=wt.save)

--- a/wt.py
+++ b/wt.py
@@ -1797,7 +1797,7 @@ def _find_binding(bindings: list[dict], issue: str = None, sprint_id: str = None
 
 def _reconcile_plan(task: dict, data: dict, sprints: list[dict], *,
                     create_issues: bool = True, close_past: bool = True,
-                    sync_hours: bool = True) -> dict:
+                    sync_hours: bool = True, closing: bool = False) -> dict:
     """Pure planner behind :func:`reconcile_task_sprints` (plan §2.3).
 
     Reads ``task``/``data``/``sprints`` and returns the ordered list of
@@ -1856,11 +1856,17 @@ def _reconcile_plan(task: dict, data: dict, sprints: list[dict], *,
     # 2. …plus the current sprint while the task is still open. This is what
     #    makes the marker-log ritual of plan §1.3 unnecessary: an open task
     #    always has a binding for new work to land on, even at 0 minutes.
+    #
+    #    ``closing=True`` suppresses that: a task being closed has no future work
+    #    to land, so reserving an empty current-sprint binding would carry its
+    #    long-lived issue onto a sprint it was never worked in and report 0h
+    #    there. With the reservation gone, ``latest`` below is the newest sprint
+    #    that actually *has* time, which is what the close reports against.
     current = find_sprint_for_date(sprints, today)
     if current:
         plan["current_sprint"] = current["title"]
         plan["current_sprint_id"] = current["id"]
-        if task.get("status") != "done":
+        if task.get("status") != "done" and not closing:
             targets.setdefault(current["id"], 0.0)
 
     target_ids = sorted((sid for sid in targets if sid in by_id), key=sort_key)
@@ -2104,6 +2110,7 @@ def _reconcile_plan(task: dict, data: dict, sprints: list[dict], *,
 def reconcile_task_sprints(task: dict, data: dict, sprints: list[dict], *,
                            create_issues: bool = True, close_past: bool = True,
                            sync_hours: bool = True, dry_run: bool = False,
+                           closing: bool = False,
                            save_callback=None, progress_callback=None) -> dict:
     """Bring a task's per-sprint issue bindings in line with its logs.
 
@@ -2112,7 +2119,10 @@ def reconcile_task_sprints(task: dict, data: dict, sprints: list[dict], *,
 
       1. Bucket logs by sprint; sprints with 0 minutes are not targets.
       2. Target set = {sprints with time} ∪ {current sprint, if the task is
-         open}. The second term replaces the marker-log ritual (plan §1.3).
+         open and ``closing`` is False}. The second term replaces the marker-log
+         ritual (plan §1.3); ``closing=True`` drops it so a task being closed
+         reports against the newest sprint that actually has time instead of an
+         empty current sprint.
       3. Target sprints with no binding get one, plus a GitHub issue when the
          task has a ``github_repo``. With ``create_issues=False`` a sprint that
          *would* need a new issue is reported in ``skipped`` (flagged
@@ -2143,6 +2153,8 @@ def reconcile_task_sprints(task: dict, data: dict, sprints: list[dict], *,
         close_past: close issues whose sprint has ended.
         sync_hours: push recomputed hours to the project.
         dry_run: plan only.
+        closing: the task is being closed, so don't reserve an empty
+            current-sprint binding for future work. Set by :func:`close_task`.
         save_callback: called after each created binding and once at the end.
         progress_callback: ``f(msg)`` progress updates.
 
@@ -2159,7 +2171,8 @@ def reconcile_task_sprints(task: dict, data: dict, sprints: list[dict], *,
             progress_callback(msg)
 
     plan = _reconcile_plan(task, data, sprints, create_issues=create_issues,
-                           close_past=close_past, sync_hours=sync_hours)
+                           close_past=close_past, sync_hours=sync_hours,
+                           closing=closing)
 
     result = {
         "success": plan["error"] is None,
@@ -2981,6 +2994,11 @@ def close_task(task: dict, data: dict, save_callback, prompt_callback=None, comm
       * Hours reported to the current issue come from
         :func:`task_reportable_mins`, i.e. the *current binding's* sprint rather
         than the task's mutable ``sprint_id``.
+      * The reconcile is passed ``closing=True``, so it does **not** reserve an
+        empty binding for the current sprint. A task being closed has no future
+        work to land, so the old behaviour carried its long-lived issue onto a
+        sprint it was never worked in and reported 0h there. Now the issue lands
+        on — and reports against — the newest sprint that actually has time.
 
     ``recurrent`` tasks still skip the reconcile entirely: they intentionally span
     sprints and are handled by ``close-recurrent`` / ``new-recurrent`` (plan
@@ -3036,7 +3054,7 @@ def close_task(task: dict, data: dict, save_callback, prompt_callback=None, comm
     # is unconditional — see the docstring for what replaced the old gate.
     all_sprints = get_all_sprints(data)
     if all_sprints and task.get("status") != "recurrent":
-        rec = reconcile_task_sprints(task, data, all_sprints,
+        rec = reconcile_task_sprints(task, data, all_sprints, closing=True,
                                      save_callback=save_callback)
         result["reconcile_result"] = rec
         result["split_result"] = _legacy_split_result(rec, task)


### PR DESCRIPTION
`close_task` now passes `closing=True` to `reconcile_task_sprints`, which suppresses the "reserve the current sprint for an open task" target. A task being closed has no future work to land there, so the old behaviour parked its long-lived issue on a sprint it was never worked in and reported **0.0h** against it.

Resolves follow-up 4 in `docs/plan-sprint-bindings.md` §6b.

### Effect on the motivating case

`Document current FE platform` — logs in Sprints 97 / 98 / 104, current sprint 105:

| | main issue `#948` | issues minted |
|---|---|---|
| before | Sprint 105 @ **0.0h** | 2 (Sprint 98, Sprint 104) |
| after | Sprint 104 @ **0.25h** | 1 (Sprint 98) |

So it both reports the right hours and mints one fewer issue.

**Open-task reconcile is deliberately unchanged** — `wt sync-sprints` still reserves the current sprint, which is what makes the marker-log ritual unnecessary.

### This one is not GitHub-neutral

Option A's "a correct change produces a zero GitHub diff" property covers phases 0–4 only, not this. Measured against merged Phase 3 across the 12 previously-split tasks: **10 byte-identical, 2 differing**, and in both the only removed writes are the current-sprint Sprint field, the absorbed past-sprint mint, and the 0.0h report. `tools/test_phase3.py` now asserts that exact allow-list, so any *other* disappearing write fails the build.

### Verification

All four harnesses green (`test_reconcile`, `test_phase3`, `test_mcp_phase3`, `test_tracker_phase3` 66/66). Invariants hold on a fresh copy of the live data with minutes (26620.71) and log count (392) unchanged. Live data file untouched; no `gh` invocation.

Harness assertions that encoded the old close behaviour were **updated, not deleted** — `test_reconcile` group 11 and the MCP close test now plan with `closing=True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)