### PR TITLE
Withhold hours writes when part of a task's time has no issue

### DIFF
--- a/.claude/skills/close-sprint/SKILL.md
+++ b/.claude/skills/close-sprint/SKILL.md
@@ -80,6 +80,11 @@ Read the dry-run output carefully before approving:
   those tasks individually instead of running `--all --create-issues`.
 - **`recurrent` tasks are always skipped** and listed as such — steps 1 and 2
   own them.
+- **`HOLD` lines mean hours were withheld.** If a task has time in a sprint
+  that has no issue, reconcile refuses to narrow its *other* issues, because
+  that would delete the unreported time from the project. Adding
+  `--create-issues` gives that time an issue and clears the hold. Never work
+  around a HOLD by editing Hours by hand.
 - Rounding is up-per-sprint (`mins_to_quarter_hours`), unchanged, so a stray
   1-minute log in a sprint bills 0.25h. If a `create` line shows a suspiciously
   tiny sprint, check whether that log is misfiled before approving.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -645,7 +645,12 @@ a pure diff between derived target state and existing bindings —
 3. Create a binding (and issue, if the task has a `github_repo`) for each
    missing target sprint. New issues are for *past* sprints and keep the
    ` (Sprint N)` title suffix.
-4. Set each binding's Hours, but only when it differs from `hours_synced`.
+4. Set each binding's Hours, but only when it differs from `hours_synced` —
+   **unless some of the task's time has no issue to report on** (a sprint
+   deferred by `create_issues=False`, or a binding that was never linked). Then
+   every hours write for that task is withheld and shown as `HOLD`, because
+   narrowing the other issues would delete that time from the project's
+   reporting. `--create-issues` binds the deferred sprint and clears it.
 5. Close any binding whose sprint has ended (Status=Done + `gh issue close`).
 6. Never delete a binding. Never touch `logs`.
 

--- a/docs/plan-sprint-bindings.md
+++ b/docs/plan-sprint-bindings.md
@@ -422,6 +422,30 @@ Deliberately left out of scope so the phases stayed reviewable. None affects the
    newest sprint, and (c) `add_to_project_and_update` reporting 0.25h where it
    used to report 0.0h. `tools/test_phase3.py` asserts exactly that allow-list,
    so any *other* removed write fails the build.
+4b. ~~**Narrowing an issue's Hours can delete reported time.**~~ **FIXED
+   2026-07-31.** Reconcile makes each issue carry *its own* sprint's hours, which
+   is only conservative when every other sprint's hours land on an issue of their
+   own. With `create_issues=False` (the `--all` default) a deferred sprint has
+   nowhere to go, so narrowing the *other* issues silently dropped the
+   difference.
+
+   Found by the first live `--all --dry-run`: reading the current Hours off all
+   49 target issues gave 41 no-op writes, 2 corrections upward, and **6 narrowing
+   writes totalling ~26h**. `Assist on Banco Galicia` alone (Sprint 95 12h30m +
+   Sprint 96 6h30m on one issue at 19.0h) would have been set to 6.5h with Sprint
+   95's 12.5h reported nowhere.
+
+   `_reconcile_plan` now computes `plan["unbillable"]` — sprints with logged time
+   that end up with no issue, whether deferred by `create_issues=False` or bound
+   to an issue-less binding. While it is non-empty, **every** hours write for
+   that task is withheld and surfaced as a `HOLD` line plus a `WHY` explaining
+   how to clear it. The test is structural, so it costs no network call. Sprints
+   getting a freshly-minted issue in the same plan count as billable, so
+   `--create-issues` clears the guard instead of tripping it, and `close_task`
+   (which always mints) is never affected. Verified live: 49 hours writes → 43,
+   exactly the 41 no-ops plus the 2 upward corrections. Covered by
+   `tools/test_reconcile.py` group 12.
+
 5. **A stray 8-second timer log mints a whole past-sprint issue** billed at
    0.25h, because `mins_to_quarter_hours` rounds up per sprint (preserved
    deliberately, §5). A minimum-minutes threshold in `_reconcile_plan` would

--- a/tools/test_phase3.py
+++ b/tools/test_phase3.py
@@ -882,19 +882,31 @@ def test_close_task_github_diff(migrated, scratch):
           "the only removed writes are current-sprint Sprint fields, absorbed "
           "past-sprint issue mints, and the 0.0h report",
           "\n      ".join(unexplained))
-    check(any("NEW#" in l for l in removed),
-          "at least one past-sprint issue is no longer minted "
-          "(absorbed by the carried-forward issue)", str(len(removed)))
-    # The point of the change: the main issue stops being told 0.0h.
+    # The two assertions below describe the `closing=True` change specifically.
+    # They only hold while HEAD predates it — once it is merged, HEAD *is* the
+    # new behaviour and the diff is empty of its signature. Assert them when the
+    # comparison spans that change, and say so plainly when it doesn't, rather
+    # than failing on a moving baseline.
     zero_before = [l for l in run.stdout.splitlines()
                    if l.strip().startswith("-")
                    and "add_to_project_and_update" in l and ", 0.0," in l]
     nonzero_after = [l for l in run.stdout.splitlines()
                      if l.strip().startswith("+")
                      and "add_to_project_and_update" in l and ", 0.0," not in l]
-    check(zero_before and nonzero_after,
-          "a close that used to report 0.0h now reports its real sprint hours",
-          f"before={len(zero_before)} after={len(nonzero_after)}")
+    spans_closing_change = bool(zero_before or any("NEW#" in l for l in removed))
+    if spans_closing_change:
+        check(any("NEW#" in l for l in removed),
+              "at least one past-sprint issue is no longer minted "
+              "(absorbed by the carried-forward issue)", str(len(removed)))
+        check(zero_before and nonzero_after,
+              "a close that used to report 0.0h now reports its real sprint hours",
+              f"before={len(zero_before)} after={len(nonzero_after)}")
+    else:
+        print("    (HEAD already contains closing=True — its signature is not in "
+              "this diff, so those two assertions are vacuous here)")
+        check(diff == 0,
+              "with closing=True already in HEAD, close_task's GitHub writes are "
+              "unchanged by this branch", f"diff={diff}")
 
 
 def test_reconcile_harness_still_passes(fixture, migrated, baseline, scratch):

--- a/tools/test_reconcile.py
+++ b/tools/test_reconcile.py
@@ -671,6 +671,74 @@ def test_pre_migration(wt, fixture, scratch):
           str(res["planned"]))
 
 
+def test_hours_withheld_guard(wt, migrated, scratch):
+    section("12. hours are withheld when some of a task's time has no issue")
+    data = load_copy(wt, migrated, scratch / "hold.json")
+    sprints = wt.get_cached_sprints(data)
+
+    # Assist on Banco Galicia: 12h30m in Sprint 95 + 6h30m in Sprint 96, one
+    # issue. Narrowing that issue to Sprint 96 alone while Sprint 95 has nowhere
+    # to go would delete 12h30m from the project's reporting.
+    task = find(data, "Assist on Banco Galicia")
+    per = {e["sprint_title"]: e["total_mins"] for e in wt.task_sprints_with_time(task, sprints)}
+    print(f"    logs by sprint: { {k: round(v) for k, v in per.items()} }")
+    check(len(per) > 1, "the fixture task really does span sprints", str(per))
+
+    with Stubs(wt, mode="strict", sprints=sprints):
+        held = wt.reconcile_task_sprints(task, data, sprints, dry_run=True,
+                                         create_issues=False)
+        freed = wt.reconcile_task_sprints(task, data, sprints, dry_run=True,
+                                          create_issues=True)
+
+    held_hours = [o for o in held["planned"] if o["op"] == "hours"]
+    withheld = [s for s in held["skipped"] if s.get("withheld_hours")]
+    check(held_hours == [], "create_issues=False plans no hours write",
+          str(held_hours))
+    check(len(withheld) == 1, "and reports exactly one withheld hours write",
+          str(withheld))
+    check([e["sprint"] for e in held["unbillable"]] == ["Sprint 95"],
+          "naming the sprint whose time has no issue",
+          str(held["unbillable"]))
+    # The withheld value must be the *narrowing* one — that's the whole hazard.
+    check(withheld and withheld[0]["hours"] < wt.mins_to_quarter_hours(sum(per.values())),
+          "the withheld value is lower than the task's full logged total",
+          str(withheld[0]["hours"] if withheld else None))
+    lines = wt._reconcile_plan_lines(held)
+    check(any(l.startswith("HOLD") for l in lines), "plan output shows a HOLD line",
+          "\n".join(lines))
+    check(any("Add --create-issues" in l for l in lines),
+          "and explains how to clear it", "\n".join(lines))
+
+    # With create_issues=True the deferred sprint gets its own issue in the same
+    # plan, so nothing is lost and the guard must step aside.
+    freed_hours = [o for o in freed["planned"] if o["op"] == "hours"]
+    check(freed["unbillable"] == [], "create_issues=True clears unbillable",
+          str(freed["unbillable"]))
+    check(len(freed_hours) == 1, "and lets the hours write through",
+          str(freed_hours))
+    check(not any(s.get("withheld_hours") for s in freed["skipped"]),
+          "with nothing withheld", str(freed["skipped"]))
+
+    # A single-sprint task has nothing unbillable, so it is unaffected.
+    solo = find(data, "Broken New Relic Dashboard")
+    with Stubs(wt, mode="strict", sprints=sprints):
+        r = wt.reconcile_task_sprints(solo, data, sprints, dry_run=True,
+                                      create_issues=False)
+    check(r["unbillable"] == [],
+          "a single-sprint task is not affected by the guard", str(r["unbillable"]))
+    check(any(o["op"] == "hours" for o in r["planned"]),
+          "and still syncs its hours", str(r["planned"]))
+
+    # close_task always mints, so the guard must never withhold on a close.
+    closing = find(data, "Assist on Banco Galicia")
+    with Stubs(wt, mode="strict", sprints=sprints):
+        rc = wt.reconcile_task_sprints(closing, data, sprints, dry_run=True,
+                                       closing=True)
+    check(rc["unbillable"] == [],
+          "a close (closing=True, create_issues default) withholds nothing",
+          str(rc["unbillable"]))
+
+
 def main():
     if len(sys.argv) != 5:
         print(__doc__.strip(), file=sys.stderr)
@@ -697,6 +765,7 @@ def main():
     test_close_task(wt, migrated, scratch)
     test_set_sprint_drift(wt, migrated, scratch)
     test_pre_migration(wt, fixture, scratch)
+    test_hours_withheld_guard(wt, migrated, scratch)
     test_idempotency(wt, migrated, scratch, baseline)
 
     print(f"\n{CHECKS - len(FAILURES)}/{CHECKS} checks passed")

--- a/wt.py
+++ b/wt.py
@@ -1825,6 +1825,7 @@ def _reconcile_plan(task: dict, data: dict, sprints: list[dict], *,
         "ops": [],
         "skipped": [],
         "unassigned_minutes": 0.0,
+        "unbillable": [],
         "seed_legacy": False,
     }
 
@@ -2022,6 +2023,38 @@ def _reconcile_plan(task: dict, data: dict, sprints: list[dict], *,
                 "reason": "already bound",
             })
 
+    # 4a. Safety guard: never narrow an issue's Hours while some of this task's
+    # logged time has nowhere to be reported.
+    #
+    # Reconcile's job is to make each issue carry *its own* sprint's hours. That
+    # is only conservative when every other sprint's hours land on an issue of
+    # their own. If a sprint with time ends up with no issue — because
+    # create_issues=False deferred it, or because its binding was never linked —
+    # then narrowing the *other* issues silently deletes the difference from the
+    # project's reporting. Observed on real data: `Assist on Banco Galicia`
+    # (Sprint 95 12.5h + Sprint 96 6.5h) would have gone from 19.0h on one issue
+    # to 6.5h, with Sprint 95's 12.5h reported nowhere.
+    #
+    # The test is structural, so it needs no network call: if any sprint of this
+    # task has minutes but no issue to put them on, withhold *all* of the task's
+    # hours writes and say why. Passing --create-issues binds those sprints and
+    # the guard clears itself.
+    # Sprints getting a freshly-minted issue *in this same plan* are billable:
+    # the create op carries their hours, so nothing is lost.
+    will_mint = {op["sprint_id"] for op in plan["ops"]
+                 if op["op"] == "create" and op.get("create_issue")}
+    unbillable = []
+    for sid, mins in targets.items():
+        if mins <= 0 or sid not in by_id or sid in will_mint:
+            continue
+        entry = next((f for f in final if f["sprint_id"] == sid), None)
+        if entry is None or not entry.get("issue"):
+            unbillable.append({"sprint": by_id[sid]["title"], "sprint_id": sid,
+                               "minutes": mins,
+                               "hours": mins_to_quarter_hours(mins)})
+    unbillable.sort(key=lambda e: sort_key(e["sprint_id"]))
+    plan["unbillable"] = unbillable
+
     # 4. Hours: push only when the value differs from what we last told GitHub.
     for f in final:
         sid = f["sprint_id"]
@@ -2041,6 +2074,15 @@ def _reconcile_plan(task: dict, data: dict, sprints: list[dict], *,
                   "from_hours": f["hours_synced"]}
         if not f["issue"]:
             plan["skipped"].append({**common, "reason": "binding has no issue"})
+        elif unbillable:
+            where = ", ".join(f"{e['sprint']} {fmt_mins(e['minutes'])}"
+                              for e in unbillable)
+            plan["skipped"].append({
+                **common, "withheld_hours": True,
+                "reason": ("hours withheld — unreported time in " + where +
+                           "; re-run with --create-issues so it lands on its "
+                           "own issue"),
+            })
         elif not sync_hours:
             plan["skipped"].append({**common, "reason": "sync_hours=False"})
         elif not has_project:
@@ -2191,6 +2233,7 @@ def reconcile_task_sprints(task: dict, data: dict, sprints: list[dict], *,
         "skipped": list(plan["skipped"]),
         "errors": [],
         "unassigned_minutes": plan["unassigned_minutes"],
+        "unbillable": plan["unbillable"],
         "bindings": [],
     }
 
@@ -6393,6 +6436,18 @@ def _reconcile_plan_lines(res: dict) -> list[str]:
             # reconcile only mints issues for *unbound* sprints.
             lines.append(f"note    {sk.get('sprint'):<12} {fmt_mins(sk['minutes'])} bound but "
                          f"never linked to an issue — use 'wt link' or 'wt done'")
+        elif sk.get("withheld_hours"):
+            was = sk.get("from_hours")
+            was_s = "unknown" if was is None else f"{was}h"
+            lines.append(f"HOLD    {sk.get('sprint'):<12} {sk['issue']}: would set "
+                         f"{was_s} → {sk['hours']}h, withheld")
+    if res.get("unbillable"):
+        where = ", ".join(f"{e['sprint']} {fmt_mins(e['minutes'])}"
+                          for e in res["unbillable"])
+        lines.append(f"WHY     {'':<12} hours withheld because this task's time in "
+                     f"{where} has no issue to report on.")
+        lines.append(f"        {'':<12} Narrowing the other issues would delete that "
+                     f"time from the project. Add --create-issues.")
     if res.get("unassigned_minutes"):
         lines.append(f"note    {'':<12} {fmt_mins(res['unassigned_minutes'])} of logs fall "
                      f"outside every sprint (not reported to GitHub)")


### PR DESCRIPTION
Found by the first live `wt sync-sprints --all --dry-run`, before any real write.

Reconcile narrows each issue to *its own* sprint's hours. That's only conservative when every other sprint's hours land on an issue of their own. With `create_issues=False` — the `--all` default — a deferred sprint has nowhere to go, so narrowing the other issues **silently deleted the difference** from the GitHub Project.

### The evidence

I read the current Hours off all 49 target issues: **41 no-op writes, 2 corrections upward, 6 narrowing writes totalling ~26h.**

| Issue | now → planned | Task | Time that stops being reported |
|---|---|---|---|
| `#5069` | 19.0 → 6.5 | Assist on Banco Galicia | **12.5h** (Sprint 95) |
| `#5263` | 6.0 → 0.25 | casanabria - Brokkr support | 5.75h (Sprint 97) |
| `#5719` | 4.25 → 0.5 | Ad-hoc Slack Questions - Sprint 101 | 3.75h |
| `#5830` | 2.75 → 0.75 | Ad-hoc Slack Questions - Sprint 102 | 2.0h |
| `#5720` | 2.25 → 0.5 | Time tracking - Sprint 101 | 1.75h |
| `#5983` | 1.25 → 0.5 | Time tracking - Sprint 103 | 0.75h |

So the seemingly-safe form (`--all` without `--create-issues`) was the *most* dangerous one.

### The guard

`_reconcile_plan` now computes `plan["unbillable"]` — sprints with logged time that end up with no issue, whether deferred by `create_issues=False` or bound to an issue-less binding. While that list is non-empty, **every** hours write for the task is withheld and surfaced as a `HOLD` line plus a `WHY` explaining how to clear it.

The check is **structural**, so it costs no network call. Sprints getting a freshly-minted issue in the same plan count as billable, so `--create-issues` clears the guard rather than tripping it, and `close_task` (which always mints) is never affected.

### Verification

Live dry-run: **49 hours writes → 43** — exactly the 41 no-ops plus the 2 upward corrections. All six narrowing writes now `HOLD`; both legitimate increases still go through.

Four harnesses green, new `tools/test_reconcile.py` group 12 covers withhold, clear-on-mint, single-sprint tasks, and the `closing=True` path. Nothing written to GitHub; data file hash unchanged.

Also de-brittled two assertions I added in #28: they described the `closing=True` diff relative to `HEAD:wt.py`, which is now merged, so they were failing on a moving baseline. They now assert that signature only when the comparison actually spans the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
