### PR TITLE
Memoise project metadata instead of re-fetching it per task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -849,6 +849,7 @@ Authoritative signatures (use these instead of guessing — see live values via 
 - `update_project_activity(issue_ref, activity, data, project_info=None, item_id=None) -> bool`
 - `update_project_type(issue_ref, type_val, data, project_info=None, item_id=None) -> bool`
 - `get_project_hours(issue_ref, data) -> float | None`
+- `get_project_info(data, refresh=False) -> dict` — **memoised** for `PROJECT_INFO_TTL_SECONDS` (300s) per (owner, project number); the uncached fetch is `_fetch_project_info` and costs two GraphQL-backed `gh project` calls. Failures are never cached. Use `refresh=True` or `clear_project_info_cache()` to force a re-fetch. Before this, a `sync-sprints --all` over ~75 tasks made 118 metadata calls and exhausted the 5000-point GraphQL budget mid-run — which `gh` reports as the misleading `unknown owner type`.
 - `close_github_issue(issue_ref) -> bool`
 - `delete_github_issue(issue_ref) -> bool`
 - `get_task_repo(task) -> str | None` — reads `task["github_repo"]` (single-arg; roles carry no GitHub fields anymore)
@@ -1002,6 +1003,8 @@ wt.save(data)
 - Don't bypass `resolve_event_to_task()` in new code that logs a calendar event to a mapped task — manual `resolve_task_by_id(get_event_mapping(...))` skips the sprint-aware routing.
 - When reporting hours to a GitHub issue, use the **sprint-filtered** total (`task_reportable_mins(task, data, sprints)`), never `task_logged_mins(task)`. A cross-sprint task keeps *all* its logs on one object as the source of truth while its per-sprint hours live on separate per-sprint issues; reporting the task total double-counts. `sync_project_hours()`, `close_task()` and `reconcile_task_sprints()` all use the sprint-filtered value — keep any new GitHub-hours path consistent.
 - Don't read `task["github_issue"]` directly — use `task_current_issue(task, data)`. A task has one issue *per sprint*; the raw key is a legacy mirror of the current one.
+- Don't call `get_project_info()` in a per-task or per-field loop assuming it's cheap — it's two GraphQL calls. It's memoised now, but don't defeat that by passing `refresh=True` in a loop, and do pass `project_info=` down to the `update_project_*` helpers (they re-fetch when it's omitted).
+- **GraphQL, not REST, is the limit that bites.** `gh project` operations are GraphQL-backed with a 5000-point/hour budget; `gh api rate_limit` shows `resources.graphql` separately from `resources.core`. A rate-limited `gh project item-add` fails with `unknown owner type`, which looks like a config error but isn't.
 - Don't reintroduce a "does this task span sprints?" gate before reconciling. Reconcile is idempotent by construction; gates were how the old code needed 0-minute marker logs.
 - Don't run an all-tasks reconcile with issue creation enabled without showing the plan first — it can mint dozens of issues for sprints predating this workflow.
 

--- a/docs/plan-sprint-bindings.md
+++ b/docs/plan-sprint-bindings.md
@@ -446,6 +446,24 @@ Deliberately left out of scope so the phases stayed reviewable. None affects the
    exactly the 41 no-ops plus the 2 upward corrections. Covered by
    `tools/test_reconcile.py` group 12.
 
+4c. ~~**`get_project_info()` re-fetched per task.**~~ **FIXED 2026-07-31.**
+   Project metadata (project id + field/option ids) costs two GraphQL-backed `gh
+   project` calls and changes only when the Project itself is edited, but it was
+   re-fetched at every call site — including inside each `update_project_*`
+   helper when `project_info` wasn't passed down. A `sync-sprints --all` over ~75
+   tasks made **118** metadata calls and exhausted the 5000-point GraphQL budget
+   mid-run, failing 17 tasks with `gh`'s misleading `unknown owner type`.
+
+   Now memoised per (owner, project number) with a 300s TTL, so a burst run pays
+   once (118 → **2**) while a long-lived TUI still picks up new Activity/Type
+   options within minutes. Failures are never cached; `refresh=True` /
+   `clear_project_info_cache()` force a re-fetch. Covered by
+   `tools/test_reconcile.py` group 13.
+
+   Note the partial failure was clean: per-sprint error isolation meant every
+   successful write persisted and nothing was left half-applied, so the retry
+   only had to do the remainder.
+
 5. **A stray 8-second timer log mints a whole past-sprint issue** billed at
    0.25h, because `mins_to_quarter_hours` rounds up per sprint (preserved
    deliberately, §5). A minimum-minutes threshold in `_reconcile_plan` would

--- a/tools/test_reconcile.py
+++ b/tools/test_reconcile.py
@@ -739,6 +739,117 @@ def test_hours_withheld_guard(wt, migrated, scratch):
           str(rc["unbillable"]))
 
 
+def test_project_info_cache(wt, migrated, scratch):
+    section("13. project metadata is fetched once per run, not once per task")
+    import json as _json
+    import types as _types
+
+    class _CP:
+        def __init__(self, out):
+            self.returncode, self.stdout, self.stderr = 0, out, ""
+
+    FIELDS = _json.dumps({"fields": [
+        {"name": "Status", "id": "F1",
+         "options": [{"name": "Done", "id": "o1"}, {"name": "In Progress", "id": "o2"}]},
+        {"name": "Hours", "id": "F2"},
+        {"name": "Activity", "id": "F3", "options": []},
+        {"name": "Type", "id": "F4", "options": []},
+        {"name": "Sprint", "id": "F5"}]})
+
+    def fake_gh(log):
+        def run(argv, *a, **k):
+            log.append(" ".join(argv[:3]))
+            if argv[:3] == ["gh", "project", "view"]:
+                return _CP(_json.dumps({"id": "PVT_x"}))
+            if argv[:3] == ["gh", "project", "field-list"]:
+                return _CP(FIELDS)
+            if argv[:3] == ["gh", "project", "item-add"]:
+                return _CP(_json.dumps({"id": "PVTI_x"}))
+            return _CP("{}")
+        return _types.SimpleNamespace(run=run, PIPE=None)
+
+    real_sub, real_ttl = wt.subprocess, wt.PROJECT_INFO_TTL_SECONDS
+    try:
+        data = load_copy(wt, migrated, scratch / "pinfo.json")
+
+        # Repeated calls collapse to one fetch (two gh calls).
+        log = []
+        wt.subprocess = fake_gh(log)
+        wt.clear_project_info_cache()
+        for _ in range(20):
+            wt.get_project_info(data)
+        check(len(log) == 2, "20 get_project_info() calls make 2 gh calls", str(len(log)))
+
+        wt.get_project_info(data, refresh=True)
+        check(len(log) == 4, "refresh=True forces a re-fetch", str(len(log)))
+        wt.clear_project_info_cache()
+        wt.get_project_info(data)
+        check(len(log) == 6, "clear_project_info_cache() forces a re-fetch", str(len(log)))
+
+        # A cache hit must still return the same metadata.
+        a = wt.get_project_info(data)
+        b = wt.get_project_info(data)
+        check(a == b and a.get("project_id") == "PVT_x",
+              "a cache hit returns identical metadata", str(a.get("project_id")))
+
+        # Expiry: a non-positive TTL always re-fetches.
+        log.clear()
+        wt.PROJECT_INFO_TTL_SECONDS = -1
+        wt.clear_project_info_cache()
+        for _ in range(3):
+            wt.get_project_info(data)
+        check(len(log) == 6, "an expired entry re-fetches", str(len(log)))
+        wt.PROJECT_INFO_TTL_SECONDS = real_ttl
+
+        # Failures must never be cached, or one blip poisons the whole run.
+        attempts = []
+        def boom(argv, *a, **k):
+            attempts.append(1)
+            raise RuntimeError("network down")
+        wt.subprocess = _types.SimpleNamespace(run=boom, PIPE=None)
+        wt.clear_project_info_cache()
+        for _ in range(3):
+            try:
+                wt.get_project_info(data)
+            except Exception:
+                pass
+        check(len(attempts) == 3, "a failed fetch is not cached", str(len(attempts)))
+
+        # The regression that mattered: a whole-run reconcile must not scale its
+        # metadata fetches with the task count. `wt sync-sprints --all` doing so
+        # exhausted the 5000-point GraphQL budget mid-run.
+        sprints = wt.get_cached_sprints(data)
+        tasks = [t for t in data["tasks"] if t.get("status") != "recurrent"]
+        counts = {}
+        for mode, ttl in (("cached", real_ttl), ("uncached", -1)):
+            fresh = load_copy(wt, migrated, scratch / f"pinfo_{mode}.json")
+            log2 = []
+            wt.subprocess = fake_gh(log2)
+            wt.PROJECT_INFO_TTL_SECONDS = ttl
+            wt.clear_project_info_cache()
+            for t in [x for x in fresh["tasks"] if x.get("status") != "recurrent"]:
+                try:
+                    wt.reconcile_task_sprints(t, fresh, sprints, create_issues=False,
+                                              save_callback=lambda _d: None)
+                except Exception:
+                    pass
+            counts[mode] = sum(1 for c in log2
+                               if c in ("gh project view", "gh project field-list"))
+        wt.PROJECT_INFO_TTL_SECONDS = real_ttl
+        print(f"    {len(tasks)} tasks: metadata gh calls "
+              f"uncached={counts['uncached']} cached={counts['cached']}")
+        check(counts["cached"] == 2,
+              "a full-run reconcile fetches project metadata exactly once",
+              str(counts["cached"]))
+        check(counts["uncached"] > counts["cached"],
+              "and that is strictly fewer than the per-task behaviour",
+              f"{counts['uncached']} vs {counts['cached']}")
+    finally:
+        wt.subprocess = real_sub
+        wt.PROJECT_INFO_TTL_SECONDS = real_ttl
+        wt.clear_project_info_cache()
+
+
 def main():
     if len(sys.argv) != 5:
         print(__doc__.strip(), file=sys.stderr)
@@ -766,6 +877,7 @@ def main():
     test_set_sprint_drift(wt, migrated, scratch)
     test_pre_migration(wt, fixture, scratch)
     test_hours_withheld_guard(wt, migrated, scratch)
+    test_project_info_cache(wt, migrated, scratch)
     test_idempotency(wt, migrated, scratch, baseline)
 
     print(f"\n{CHECKS - len(FAILURES)}/{CHECKS} checks passed")

--- a/wt.py
+++ b/wt.py
@@ -920,12 +920,49 @@ PROJECT_STATUS_MAP = {
 }
 
 
-def get_project_info(data: dict) -> dict:
+# Project field metadata (project id + field/option ids) costs two GraphQL-backed
+# `gh project` calls to fetch and changes only when the GitHub Project itself is
+# edited. It used to be re-fetched per call site — `wt sync-sprints --all` over 67
+# tasks burned ~134 of them and exhausted the 5000-point GraphQL budget mid-run,
+# which surfaced as `gh`'s unhelpful "unknown owner type". Memoised per
+# (owner, project number) with a short TTL: a burst run pays for it once, while a
+# long-lived process (the TUI) still picks up new Activity/Type options within a
+# few minutes rather than needing a restart.
+PROJECT_INFO_TTL_SECONDS = 300
+_PROJECT_INFO_CACHE: dict = {}
+
+
+def clear_project_info_cache() -> None:
+    """Drop the memoised project metadata. For tests and explicit refreshes."""
+    _PROJECT_INFO_CACHE.clear()
+
+
+def get_project_info(data: dict, refresh: bool = False) -> dict:
     """Get project ID and field information.
 
     Returns dict with project_id, status_field, hours_field, status_options, etc.
     Raises Exception if project not configured or fields missing.
+
+    Memoised for ``PROJECT_INFO_TTL_SECONDS``; pass ``refresh=True`` to force a
+    re-fetch. Failures are never cached, so a transient error doesn't stick.
     """
+    config = data.get("config", {})
+    key = (config.get("github_project_owner", "grafana"),
+           config.get("github_project_number"))
+    if not refresh:
+        hit = _PROJECT_INFO_CACHE.get(key)
+        if hit and (time.time() - hit[0]) < PROJECT_INFO_TTL_SECONDS:
+            # Keep the local Activity/Type options cache warm on hits too, so
+            # behaviour matches an uncached fetch exactly.
+            save_project_options_cache(data, hit[1])
+            return hit[1]
+    info = _fetch_project_info(data)
+    _PROJECT_INFO_CACHE[key] = (time.time(), info)
+    return info
+
+
+def _fetch_project_info(data: dict) -> dict:
+    """Uncached fetch behind :func:`get_project_info` — two `gh project` calls."""
     config = data.get("config", {})
     owner = config.get("github_project_owner", "grafana")
     project_num = config.get("github_project_number")


### PR DESCRIPTION
This is the efficiency bug behind the `sync-sprints --all` failure — 17 tasks errored with `unknown owner type`, which turned out to be **GraphQL rate limiting**, not a config problem. REST core was untouched at 5000/5000 the whole time; `resources.graphql` was at 0.

### Cause

Project metadata (project id + field/option ids) costs **two GraphQL-backed `gh project` calls** and only changes when the GitHub Project itself is edited. But it was re-fetched at every call site — including inside each `update_project_*` helper whenever `project_info` wasn't passed down.

Measured over ~75 tasks: **118 metadata calls** against a 5000-point/hour budget.

### Fix

`get_project_info` is memoised per `(owner, project number)` with a 300s TTL:

- a burst run pays for it once — **118 → 2**
- a long-lived TUI still picks up new Activity/Type options within minutes rather than needing a restart
- failures are **never** cached, so one blip doesn't poison a whole run
- `refresh=True` / `clear_project_info_cache()` force a re-fetch
- cache hits still refresh the local Activity/Type options cache, so behaviour matches an uncached fetch exactly

The uncached fetch moves to `_fetch_project_info`; `get_project_info`'s signature and semantics are unchanged for all 8 existing callers.

### Verification

New `tools/test_reconcile.py` group 13 covers memoisation, `refresh=True`, `clear_project_info_cache()`, TTL expiry, failures-not-cached, identical metadata on hits, and the whole-run call count (asserting exactly 2, and strictly fewer than the per-task behaviour).

All four harnesses green. Nothing written to GitHub by this branch.

### Also documented

`CLAUDE.md` gains a "things to avoid" entry, because the diagnosis was genuinely non-obvious: **GraphQL, not REST, is the limit that bites** — `gh project` operations are GraphQL-backed, `gh api rate_limit` reports `resources.graphql` separately from `resources.core`, and a rate-limited `gh project item-add` fails with the misleading `unknown owner type`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
