### PR TITLE
Fix: the supersede op could never be planned

### DIFF
--- a/tools/test_reconcile.py
+++ b/tools/test_reconcile.py
@@ -965,6 +965,25 @@ def test_phase5_merge(wt, fixture, scratch):
                   f"{t.get('sprint')} vs {ids[-1]}")
 
     # Reconcile must plan a superseded-issue cleanup so nothing double-counts.
+    # This ran only `if supers:` before, which was False for this fixture — so the
+    # op was never exercised and a dropped field in the planner's working copy
+    # made it unplannable without any test noticing. Force the state instead.
+    forced = next(t for t in data["tasks"]
+                  if len([b for b in (t.get("sprint_issues") or []) if b.get("issue")]) >= 2)
+    fb = [b for b in forced["sprint_issues"] if b.get("issue")][0]
+    fb["superseded_issues"] = ["o/r#4242"]
+    with Stubs(wt, mode="strict", sprints=wt.get_cached_sprints(data)):
+        fr = wt.reconcile_task_sprints(forced, data, wt.get_cached_sprints(data),
+                                       dry_run=True, create_issues=True)
+    fops = [o for o in fr["planned"] if o["op"] == "supersede"]
+    check(len(fops) == 1, "a superseded issue is always planned for cleanup",
+          str([o["op"] for o in fr["planned"]]))
+    check(fops and fops[0]["issue"] == "o/r#4242" and fops[0]["hours"] == 0.0,
+          "the supersede op names the duplicate and zeroes it", str(fops))
+    check(any("SUPER" in l for l in wt._reconcile_plan_lines(fr)),
+          "and it is visible in the rendered plan")
+    fb.pop("superseded_issues", None)
+
     if supers:
         owner = next(t for t in data["tasks"]
                      if any(b.get("superseded_issues") for b in t.get("sprint_issues") or []))

--- a/wt.py
+++ b/wt.py
@@ -2156,9 +2156,14 @@ def _reconcile_plan(task: dict, data: dict, sprints: list[dict], *,
     # Working copy of the existing bindings — planning never touches the real ones.
     persisted = task.get("sprint_issues")
     if isinstance(persisted, list):
+        # NB: carry superseded_issues through. The planner works on a copy so it
+        # never mutates the real bindings, but omitting a field here silently
+        # disables anything that depends on it — that is exactly how the
+        # supersede op became unplannable after Phase 5 introduced it.
         work = [
             {"sprint_id": b.get("sprint_id"), "issue": b.get("issue"),
-             "state": b.get("state"), "hours_synced": b.get("hours_synced")}
+             "state": b.get("state"), "hours_synced": b.get("hours_synced"),
+             "superseded_issues": list(b.get("superseded_issues") or [])}
             for b in persisted
         ]
         legacy_issue = task.get("github_issue")
@@ -2289,7 +2294,9 @@ def _reconcile_plan(task: dict, data: dict, sprints: list[dict], *,
     # Post-plan binding set: existing (possibly re-pointed) plus the new ones.
     final = [
         {"sprint_id": w["sprint_id"], "issue": w["issue"], "state": w["state"],
-         "hours_synced": w["hours_synced"], "new": False}
+         "hours_synced": w["hours_synced"],
+         "superseded_issues": list(w.get("superseded_issues") or []),
+         "new": False}
         for w in work
     ]
     for op in created_plan:


### PR DESCRIPTION
`_reconcile_plan` works on a copy of the bindings so it never mutates the real ones — but that copy was built field-by-field and omitted `superseded_issues`, in **both** the `work` list and the `final` list derived from it. The supersede op iterates `final`, so it saw an empty list every time and the cleanup was never planned.

### Effect on live data

After the Phase 5 merge, `#5615` kept reporting **2.0h** for Sprint 101 while `#5719` was about to be set to that sprint's full **5.75h** — the project double-counted ~2h, and nothing in the plan proposed fixing it. Confirmed by running `wt sync-sprints "Ad-hoc Slack Questions - casanabria" --dry-run` against the real file: no `SUPER` line. With the fix:

```
SUPER   Sprint 101   grafana/field-eng#5615: zero + close
                     (duplicate of grafana/field-eng#5719 for this sprint)
```

### Why no test caught it

The Phase 5 test asserted the supersede op only inside `if supers:` — and that was False for the fixture, whose vintage predates the collision. So the path was never exercised end to end and a dropped field went unnoticed. The test now **forces** a superseded binding rather than depending on fixture state, and asserts the op is planned, names the duplicate, zeroes it, and appears in the rendered plan.

Worth remembering as a pattern: a conditional assertion that never fires is indistinguishable from a passing one.

All four harnesses green. No `gh` write from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
